### PR TITLE
Required updates for an integration with Square Repo

### DIFF
--- a/collectors/collectors-anvil-dagger/src/main/kotlin/com/squareup/af/analysis/models/KtClassInfo.kt
+++ b/collectors/collectors-anvil-dagger/src/main/kotlin/com/squareup/af/analysis/models/KtClassInfo.kt
@@ -1,0 +1,26 @@
+package com.squareup.af.analysis.models
+
+import com.squareup.af.analysis.stats.KtClassInfoKeywordData
+import org.jetbrains.kotlin.psi.KtClass
+
+/**
+ * Abstraction layer on top of [KtClass] to allow better logic testing with fakes.
+ *
+ * Feel free to add as many properties as are needed as delegates.
+ */
+interface KtClassInfo {
+    fun isInterface(): Boolean
+    fun isEnum(): Boolean
+    fun isAbstract(): Boolean
+
+    companion object {
+        fun KtClass.toKtClassInfo(): KtClassInfo = RealKtClassInfo(this)
+        fun KtClass.toKtClassInfoData(): KtClassInfoKeywordData= RealKtClassInfo(this).run {
+            KtClassInfoKeywordData(
+                isEnum = isEnum(),
+                isAbstract = isAbstract(),
+                isInterface = isInterface(),
+            )
+        }
+    }
+}

--- a/collectors/collectors-anvil-dagger/src/main/kotlin/com/squareup/af/analysis/models/RealKtClassInfo.kt
+++ b/collectors/collectors-anvil-dagger/src/main/kotlin/com/squareup/af/analysis/models/RealKtClassInfo.kt
@@ -1,0 +1,13 @@
+package com.squareup.af.analysis.models
+
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.psiUtil.isAbstract
+
+/**
+ * Delegates to a concrete implementation of [KtClass]
+ */
+class RealKtClassInfo(private val ktClass: KtClass) : KtClassInfo {
+  override fun isInterface(): Boolean = ktClass.isInterface()
+  override fun isEnum(): Boolean = ktClass.isEnum()
+  override fun isAbstract(): Boolean = ktClass.isAbstract()
+}

--- a/collectors/collectors-anvil-dagger/src/main/kotlin/com/squareup/af/analysis/stats/KtClassInfoMatchesExpectedType.kt
+++ b/collectors/collectors-anvil-dagger/src/main/kotlin/com/squareup/af/analysis/stats/KtClassInfoMatchesExpectedType.kt
@@ -1,0 +1,24 @@
+package com.squareup.af.analysis.stats
+
+import com.squareup.af.analysis.models.KtClassInfo
+
+object KtClassInfoMatchesExpectedType {
+    fun ktClassInfoKeywordMatcher(
+        actual: KtClassInfoKeywordData,
+        isInterface: Boolean,
+        isEnum: Boolean,
+        isAbstract: Boolean,
+    ): Boolean {
+        return (actual.isInterface == isInterface)
+                && (actual.isEnum == isEnum)
+                && (actual.isAbstract == isAbstract)
+    }
+}
+
+typealias KtClassInfoKeywordMatcher = (ktClassInfo: KtClassInfoKeywordData) -> Boolean
+
+data class KtClassInfoKeywordData(
+    val isInterface: Boolean,
+    val isEnum: Boolean,
+    val isAbstract: Boolean,
+)

--- a/collectors/collectors-anvil-dagger/src/main/kotlin/com/squareup/af/analysis/stats/classdefinition/SupertypeDefinitionStatCollector.kt
+++ b/collectors/collectors-anvil-dagger/src/main/kotlin/com/squareup/af/analysis/stats/classdefinition/SupertypeDefinitionStatCollector.kt
@@ -1,0 +1,88 @@
+package com.squareup.af.analysis.stats.classdefinition
+
+import com.squareup.af.analysis.models.KtClassInfo.Companion.toKtClassInfo
+import com.squareup.af.analysis.models.KtClassInfo.Companion.toKtClassInfoData
+import com.squareup.af.analysis.stats.KtClassInfoKeywordMatcher
+import com.squareup.af.analysis.stats.classdefinition.model.ClassDefinitionInfo
+import com.squareup.invert.CollectedStat
+import com.squareup.invert.StatCollector
+import com.squareup.invert.models.Stat.StringStat
+import com.squareup.invert.models.StatMetadata
+import com.squareup.psi.requireFqName
+import com.squareup.psi.toKtFile
+import org.jetbrains.kotlin.psi.KtClass
+import java.io.File
+
+open class SupertypeDefinitionStatCollector(
+    private val statInfo: StatMetadata,
+    val supertypes: Set<String>,
+    val classMatchesExpectedType: KtClassInfoKeywordMatcher,
+) : StatCollector {
+
+    override fun collect(
+        rootProjectFolder: File,
+        projectPath: String,
+        kotlinSourceFiles: List<File>,
+    ): List<CollectedStat>? {
+        val definedMatchingClasses = mutableListOf<ClassDefinitionInfo>()
+        kotlinSourceFiles.forEach { file ->
+            definedMatchingClasses.addAll(
+                collectForClassDeclarations(
+                    relativePath = file.absolutePath.replace(rootProjectFolder.absolutePath, "").drop(1),
+                    supertypes = supertypes,
+                    declaredKtClasses = file.toKtFile().declarations.filterIsInstance<KtClass>(),
+                )
+            )
+        }
+        return if (definedMatchingClasses.isNotEmpty()) {
+            listOf(CollectedStat(statInfo, StringStat(definedMatchingClasses.joinToString("\n") { it.fqName })))
+        } else {
+            null
+        }
+    }
+
+    override fun getName(): String {
+        return this::class.java.name
+    }
+
+    /**
+     * Given a list of declared classes in a given file, and a list of desired supertypes,
+     * the implementer of this method should determine if the class declaration
+     * should be collected based it their criteria (is abstract, interface, naming, etc).
+     *
+     * @return A [List] of [ClassDefinitionsStat]s with the definitions that
+     * we should capture as part of this stat.
+     */
+    open fun collectForClassDeclarations(
+        relativePath: String,
+        supertypes: Set<String>,
+        declaredKtClasses: List<KtClass>,
+    ): List<ClassDefinitionInfo> {
+        val collectedDefinitions = mutableListOf<ClassDefinitionInfo>()
+
+        declaredKtClasses.forEach { ktClass: KtClass ->
+            if (classMatchesExpectedType(ktClass.toKtClassInfoData())) {
+                val className = ktClass.name.toString()
+                val actualSupertypes = getDirectSupertypes(ktClass)
+                if (actualSupertypes.any { supertypes.contains(it) }) {
+                    collectedDefinitions.add(
+                        ClassDefinitionInfo(
+                            name = className,
+                            fqName = ktClass.fqName?.asString() ?: className,
+                            file = relativePath,
+                            supertypes = actualSupertypes
+                        )
+                    )
+                }
+            }
+        }
+        return collectedDefinitions.toList()
+    }
+
+    /** These are direct supertypes only and does not reflect an entire class hierarchy */
+    protected fun getDirectSupertypes(
+        ktClass: KtClass
+    ): List<String> = ktClass.getSuperTypeList()
+        ?.entries
+        ?.map { it.requireFqName().asString() } ?: listOf()
+}

--- a/collectors/collectors-anvil-dagger/src/main/kotlin/com/squareup/af/analysis/stats/classdefinition/model/ClassDefinitionInfo.kt
+++ b/collectors/collectors-anvil-dagger/src/main/kotlin/com/squareup/af/analysis/stats/classdefinition/model/ClassDefinitionInfo.kt
@@ -1,0 +1,8 @@
+package com.squareup.af.analysis.stats.classdefinition.model
+
+data class ClassDefinitionInfo(
+  val name: String,
+  val fqName: String,
+  val file: String,
+  val supertypes: List<String>,
+)

--- a/collectors/collectors-anvil-dagger/src/main/kotlin/com/squareup/af/analysis/stats/hasimport/HasImportStatCollector.kt
+++ b/collectors/collectors-anvil-dagger/src/main/kotlin/com/squareup/af/analysis/stats/hasimport/HasImportStatCollector.kt
@@ -1,0 +1,55 @@
+package com.squareup.af.analysis.stats.hasimport
+
+import com.squareup.invert.CollectedStat
+import com.squareup.invert.StatCollector
+import com.squareup.invert.models.Stat.BooleanStat
+import com.squareup.invert.models.StatMetadata
+import com.squareup.psi.toKtFile
+import org.jetbrains.kotlin.psi.KtFile
+import java.io.File
+
+/**
+ * Layer on top of [HasImportStatCollector] that helps collect data for Square's android-register.
+ */
+abstract class HasImportStatCollector(
+  private val statInfo: StatMetadata,
+  /** Will succeed if ANY of these imports match */
+  private val desiredImports: List<String>
+) : StatCollector {
+  override fun collect(
+    rootProjectFolder: File,
+    projectPath: String,
+    kotlinSourceFiles: List<File>,
+  ): List<CollectedStat>? {
+    return collectFromFileContents(kotlinSourceFiles.map { it.toKtFile() })
+  }
+
+  private fun collectFromFileContents(
+    kotlinSourceFileContents: List<KtFile>
+  ): List<CollectedStat>? {
+    val referencedInFiles = kotlinSourceFileContents
+      .filter { ktFile ->
+        ktFile.importDirectives.any { importDirective ->
+          val importPath = importDirective.importPath?.pathStr.orEmpty()
+          desiredImports.contains(importPath)
+        }
+      }
+    return if (referencedInFiles.isNotEmpty()) {
+      listOf(
+        CollectedStat(
+          statInfo,
+          BooleanStat(
+            details = "Referenced in ${referencedInFiles.map { it.name }}",
+            value = referencedInFiles.isNotEmpty(),
+          )
+        )
+      )
+    } else {
+      null
+    }
+  }
+
+  override fun getName(): String {
+    return this::class.java.name
+  }
+}

--- a/collectors/collectors-anvil-dagger/src/main/kotlin/com/squareup/psi/PsiKotlin.kt
+++ b/collectors/collectors-anvil-dagger/src/main/kotlin/com/squareup/psi/PsiKotlin.kt
@@ -1,7 +1,6 @@
 package com.squareup.psi
 
-import org.jetbrains.kotlin.com.intellij.psi.PsiElement
-import org.jetbrains.kotlin.com.intellij.psi.PsiFileFactory
+import org.jetbrains.kotlin.com.intellij.psi.*
 import org.jetbrains.kotlin.idea.KotlinFileType
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.name.Name
@@ -19,6 +18,7 @@ import org.jetbrains.kotlin.psi.KtSuperTypeListEntry
 import org.jetbrains.kotlin.psi.KtTypeArgumentList
 import org.jetbrains.kotlin.psi.KtTypeReference
 import org.jetbrains.kotlin.psi.KtUserType
+import org.jetbrains.kotlin.psi.psiUtil.parents
 import org.jetbrains.kotlin.psi.psiUtil.parentsWithSelf
 import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstance
 import java.io.File
@@ -219,3 +219,17 @@ private fun PsiElement.requireFqNameList(): List<FqName> {
     // That's what we mostly care about.
     return listOf(containingKtFile.packageFqName.child(Name.identifier(classReference)))
 }
+val PsiMethod.fqName: FqName
+    get() {
+        val packageName = parents.filterIsInstance<PsiJavaFile>().first().packageName
+            .let { if (it.isBlank()) "" else "$it." }
+
+        val classNames = parents
+            .filterIsInstance<PsiClass>()
+            .map { requireNotNull(it.name) }
+            .toList()
+            .reversed()
+            .joinToString(separator = ".", postfix = ".")
+
+        return FqName("$packageName${classNames}$name")
+    }

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -1,5 +1,3 @@
-ext.set("invertVersion", "0.0.1-dev-SNAPSHOT")
-
 buildscript {
     repositories {
         mavenLocal()

--- a/examples/settings.gradle.kts
+++ b/examples/settings.gradle.kts
@@ -1,3 +1,5 @@
+rootProject.name = "Invert Examples"
+
 pluginManagement {
     repositories {
         google()

--- a/invert-gradle-plugin/build.gradle.kts
+++ b/invert-gradle-plugin/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.vanniktech.maven.publish.SonatypeHost
-
 plugins {
     kotlin("jvm")
     kotlin("plugin.serialization")
@@ -17,7 +15,12 @@ gradlePlugin {
 }
 
 java {
-//    withSourcesJar()
+    withSourcesJar()
+}
+
+tasks.named<Jar>("sourcesJar") {
+    // Allow overwriting of HTML & JS files in resources/META-INF during publishing
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }
 
 dependencies {


### PR DESCRIPTION
Made changes to move some general code into the `square/invert` repo in a way to facilitate integration for Square's use.