### PR TITLE
Making invert more build system agnostic.

### DIFF
--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/InvertAllCollectedDataRepo.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/InvertAllCollectedDataRepo.kt
@@ -21,7 +21,7 @@ class InvertAllCollectedDataRepo(
 
   val httpsRemoteRepoUrlForCommit: String = "${projectMetadata.remoteRepoUrl}/blob/${projectMetadata.latestCommitGitSha}"
 
-  val mavenRepoUrls = projectMetadata.mavenRepoUrls
+  val mavenRepoUrls = projectMetadata.artifactRepositories
 
   val projectPaths: Set<ModulePath> by lazy {
     mutableSetOf<String>().apply {

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/tasks/ProjectMetadataCollector.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/tasks/ProjectMetadataCollector.kt
@@ -3,6 +3,7 @@ package com.squareup.invert.internal.tasks
 import com.squareup.invert.internal.GitDataCollector
 import com.squareup.invert.logging.InvertLogger
 import com.squareup.invert.models.GitBranch
+import com.squareup.invert.models.js.BuildSystem
 import com.squareup.invert.models.js.MetadataJsReportModel
 import java.io.File
 import java.time.Instant
@@ -42,6 +43,13 @@ object ProjectMetadataCollector {
       remoteGitRepoUrl
     }
 
+    val buildSystem = if (gitProjectDir.listFiles().any { it.name.contains(".gradle") }) {
+      // Has a settings.gradle or settings.gradle.kts or build.gradle or build.gradle.kts file in the root
+      BuildSystem.GRADLE
+    } else {
+      BuildSystem.OTHER
+    }
+
     return MetadataJsReportModel(
       currentTime = time.epochSecond,
       currentTimeStr = formatter.format(time),
@@ -54,7 +62,8 @@ object ProjectMetadataCollector {
       latestCommitSha = currentBranchHash,
       remoteRepoGit = remoteGitRepoUrl,
       remoteRepoUrl = remoteRepoUrl,
-      mavenRepoUrls = repoUrls,
+      artifactRepositories = repoUrls,
+      buildSystem = buildSystem,
     )
   }
 

--- a/invert-models/src/commonMain/kotlin/com/squareup/invert/models/js/BuildSystem.kt
+++ b/invert-models/src/commonMain/kotlin/com/squareup/invert/models/js/BuildSystem.kt
@@ -1,0 +1,6 @@
+package com.squareup.invert.models.js
+
+enum class BuildSystem {
+  GRADLE,
+  OTHER,
+}

--- a/invert-models/src/commonMain/kotlin/com/squareup/invert/models/js/MetadataJsReportModel.kt
+++ b/invert-models/src/commonMain/kotlin/com/squareup/invert/models/js/MetadataJsReportModel.kt
@@ -21,5 +21,6 @@ data class MetadataJsReportModel(
     val tagName: GitTag?,
     val remoteRepoGit: String,
     val remoteRepoUrl: String,
-    val mavenRepoUrls: List<String>
+    val artifactRepositories: List<String>,
+    val buildSystem: BuildSystem,
 )

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/navigation/NavGroupsRepo.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/navigation/NavGroupsRepo.kt
@@ -75,29 +75,6 @@ object DefaultNavItems {
         )
       ),
       NavPageGroup(
-        "Gradle", setOf(
-          GradlePluginsReportPage.navPage.toNavItem().copy(
-            matchesCurrentNavRoute = {
-              it is GradlePluginsNavRoute || it is PluginDetailNavRoute
-            },
-            destinationNavRoute = GradlePluginsNavRoute(null)
-          ),
-          ArtifactsReportPage.navPage.toNavItem().copy(
-            matchesCurrentNavRoute = {
-              it is ArtifactsNavRoute || it is ArtifactDetailNavRoute
-            }
-          ),
-          GradleRepositoriesReportPage.navPage.toNavItem(),
-          ConfigurationsNavRoute.navPage.toNavItem().copy(
-            matchesCurrentNavRoute = {
-              it is ConfigurationsNavRoute || it is ConfigurationDetailNavRoute
-            }
-          ),
-          AnnotationProcessorsReportPage.navPage.toNavItem(),
-          KotlinCompilerPluginsReportPage.navPage.toNavItem(),
-        )
-      ),
-      NavPageGroup(
         "Insights", setOf(
           LeafModulesNavRoute.navPage.toNavItem(),
           UnusedModulesReportPage.navPage.toNavItem(),

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/GradleRepositoriesReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/GradleRepositoriesReportPage.kt
@@ -53,7 +53,7 @@ fun GradleRepositoriesComposable(
     }
     Br()
     Ul({ classes("fs-6") }) {
-        metadata!!.mavenRepoUrls.forEach { mavenRepoUrl ->
+        metadata!!.artifactRepositories.forEach { mavenRepoUrl ->
             Li {
                 A(href = mavenRepoUrl) {
                     Text(mavenRepoUrl)

--- a/invert-report/src/jsMain/kotlin/navigation/NavigationComposables.kt
+++ b/invert-report/src/jsMain/kotlin/navigation/NavigationComposables.kt
@@ -9,6 +9,18 @@ import com.squareup.invert.common.navigation.NavPage
 import com.squareup.invert.common.navigation.NavPageGroup
 import com.squareup.invert.common.navigation.NavRoute
 import com.squareup.invert.common.navigation.NavRouteRepo
+import com.squareup.invert.common.navigation.toNavItem
+import com.squareup.invert.common.pages.AnnotationProcessorsReportPage
+import com.squareup.invert.common.pages.ArtifactDetailNavRoute
+import com.squareup.invert.common.pages.ArtifactsNavRoute
+import com.squareup.invert.common.pages.ArtifactsReportPage
+import com.squareup.invert.common.pages.ConfigurationDetailNavRoute
+import com.squareup.invert.common.pages.ConfigurationsNavRoute
+import com.squareup.invert.common.pages.GradlePluginsNavRoute
+import com.squareup.invert.common.pages.GradlePluginsReportPage
+import com.squareup.invert.common.pages.GradleRepositoriesReportPage
+import com.squareup.invert.common.pages.KotlinCompilerPluginsReportPage
+import com.squareup.invert.common.pages.PluginDetailNavRoute
 import com.squareup.invert.common.utils.FormattingUtils.dateDisplayStr
 import org.jetbrains.compose.web.attributes.ATarget.Blank
 import org.jetbrains.compose.web.attributes.target
@@ -37,7 +49,37 @@ fun LeftNavigationComposable(
   Ul({ classes("list-unstyled", "ps-0") }) {
     val random = Random(0)
     val navGroups by navGroupsRepo.navGroups.collectAsState(setOf())
-    navGroups
+    navGroups.let {
+      if (metadataOrig?.artifactRepositories?.isNotEmpty() == true) {
+        it.plus(
+          NavPageGroup(
+            "Gradle", setOf(
+              GradlePluginsReportPage.navPage.toNavItem().copy(
+                matchesCurrentNavRoute = {
+                  it is GradlePluginsNavRoute || it is PluginDetailNavRoute
+                },
+                destinationNavRoute = GradlePluginsNavRoute(null)
+              ),
+              ArtifactsReportPage.navPage.toNavItem().copy(
+                matchesCurrentNavRoute = {
+                  it is ArtifactsNavRoute || it is ArtifactDetailNavRoute
+                }
+              ),
+              GradleRepositoriesReportPage.navPage.toNavItem(),
+              ConfigurationsNavRoute.navPage.toNavItem().copy(
+                matchesCurrentNavRoute = {
+                  it is ConfigurationsNavRoute || it is ConfigurationDetailNavRoute
+                }
+              ),
+              AnnotationProcessorsReportPage.navPage.toNavItem(),
+              KotlinCompilerPluginsReportPage.navPage.toNavItem(),
+            )
+          ),
+        )
+      } else {
+        it
+      }
+    }
       .forEach { navPageGroup: NavPageGroup ->
         val collapseId = "nav-group-id-" + random.nextInt()
         Li({ classes("mb-1") }) {


### PR DESCRIPTION
 Added a "BuildSystem" field and renamed `mavenRepoUrls` to `artifactRepositories` to be more agnostic.  Only showing "Gradle" navigation items if it is using the Gradle build system.