### PR TITLE
Ownership Revamp

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/configure-pages@v3
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v4
         with:
           # Upload the generated pages
           path: './build/static'

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/InvertAllCollectedDataRepo.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/InvertAllCollectedDataRepo.kt
@@ -52,7 +52,7 @@ class InvertAllCollectedDataRepo(
       collectedOwners = allCollectedData.collectedOwners.firstOrNull { it.path == modulePath }
         ?: CollectedOwnershipForProject(
           path = modulePath,
-          ownerInfo = OwnerInfo("None"),
+          ownerName = OwnerInfo.UNOWNED,
         ),
       collectedStats = allCollectedData.collectedStats.firstOrNull { it.path == modulePath }
         ?: CollectedStatsForProject(

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/InvertCollectContext.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/InvertCollectContext.kt
@@ -10,6 +10,7 @@ class InvertCollectContext(
   val gitCloneDir: File,
   val modulePath: ModulePath,
   val moduleDir: File,
+  val ownershipCollector: InvertOwnershipCollector,
 )
 
 val InvertCollectContext.projectSrcDir get() = File(moduleDir, "src")

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/InvertExtension.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/InvertExtension.kt
@@ -2,7 +2,7 @@ package com.squareup.invert
 
 import com.squareup.invert.internal.IncludeAnySubprojectCalculator
 import com.squareup.invert.internal.IncludeRuntimeClasspathConfigurationsCalculator
-import com.squareup.invert.internal.NoOpOwnershipCollector
+import com.squareup.invert.internal.NoOpInvertOwnershipCollector
 import com.squareup.invert.models.ConfigurationName
 import org.gradle.api.Project
 import org.gradle.api.tasks.Input
@@ -106,7 +106,7 @@ open class InvertExtension(project: Project) {
 
   internal fun getOwnershipCollector(): InvertOwnershipCollector {
     return ownershipCollectorProperty.getOrElse(
-      NoOpOwnershipCollector
+      NoOpInvertOwnershipCollector
     )
   }
 }

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/InvertOwnershipCollector.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/InvertOwnershipCollector.kt
@@ -2,13 +2,22 @@ package com.squareup.invert
 
 import com.squareup.invert.models.ModulePath
 import com.squareup.invert.models.OwnerInfo
+import com.squareup.invert.models.OwnerName
+import java.io.File
 
 /**
  * Allows a user of Invert to specify how ownership is calculated.
  */
-interface InvertOwnershipCollector {
-  fun collect(
-    rootProjectDir: String,
+abstract class InvertOwnershipCollector {
+  abstract fun collect(
+    rootProjectDir: File,
     modulePath: ModulePath
   ): OwnerInfo
+
+  open fun getOwnerNameForFile(
+    rootProjectDir: File,
+    fileInProject: File
+  ): OwnerName {
+    return OwnerInfo.UNOWNED
+  }
 }

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/InvertOwnershipCollector.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/InvertOwnershipCollector.kt
@@ -1,7 +1,5 @@
 package com.squareup.invert
 
-import com.squareup.invert.models.ModulePath
-import com.squareup.invert.models.OwnerInfo
 import com.squareup.invert.models.OwnerName
 import java.io.File
 
@@ -9,13 +7,9 @@ import java.io.File
  * Allows a user of Invert to specify how ownership is calculated.
  */
 interface InvertOwnershipCollector {
-  fun collect(
-    rootProjectDir: File,
-    modulePath: ModulePath
-  ): OwnerName
 
-  fun getOwnerNameForFile(
-    rootProjectDir: File,
-    fileInProject: File
+  fun collect(
+    gitRootDir: File,
+    fileWithOwnership: File
   ): OwnerName
 }

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/InvertOwnershipCollector.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/InvertOwnershipCollector.kt
@@ -8,16 +8,14 @@ import java.io.File
 /**
  * Allows a user of Invert to specify how ownership is calculated.
  */
-abstract class InvertOwnershipCollector {
-  abstract fun collect(
+interface InvertOwnershipCollector {
+  fun collect(
     rootProjectDir: File,
     modulePath: ModulePath
-  ): OwnerInfo
+  ): OwnerName
 
-  open fun getOwnerNameForFile(
+  fun getOwnerNameForFile(
     rootProjectDir: File,
     fileInProject: File
-  ): OwnerName {
-    return OwnerInfo.UNOWNED
-  }
+  ): OwnerName
 }

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/NoOpInvertOwnershipCollector.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/NoOpInvertOwnershipCollector.kt
@@ -2,6 +2,7 @@ package com.squareup.invert.internal
 
 import com.squareup.invert.InvertOwnershipCollector
 import com.squareup.invert.models.ModulePath
+import com.squareup.invert.models.OwnerInfo
 import com.squareup.invert.models.OwnerName
 import java.io.File
 
@@ -12,5 +13,5 @@ object NoOpInvertOwnershipCollector : InvertOwnershipCollector {
   override fun collect(
     gitRootDir: File,
     fileWithOwnership: File
-  ): OwnerName = "NoOp Invert Ownership"
+  ): OwnerName = OwnerInfo.UNOWNED
 }

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/NoOpInvertOwnershipCollector.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/NoOpInvertOwnershipCollector.kt
@@ -9,14 +9,8 @@ import java.io.File
  * Default implementation of [InvertOwnershipCollector] which provides no ownership.
  */
 object NoOpInvertOwnershipCollector : InvertOwnershipCollector {
-
   override fun collect(
-    rootProjectDir: File,
-    modulePath: ModulePath
-  ): OwnerName = "NoOp Invert Ownership"
-
-  override fun getOwnerNameForFile(
-    rootProjectDir: File,
-    fileInProject: File
+    gitRootDir: File,
+    fileWithOwnership: File
   ): OwnerName = "NoOp Invert Ownership"
 }

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/NoOpInvertOwnershipCollector.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/NoOpInvertOwnershipCollector.kt
@@ -2,16 +2,21 @@ package com.squareup.invert.internal
 
 import com.squareup.invert.InvertOwnershipCollector
 import com.squareup.invert.models.ModulePath
-import com.squareup.invert.models.OwnerInfo
+import com.squareup.invert.models.OwnerName
 import java.io.File
 
 /**
  * Default implementation of [InvertOwnershipCollector] which provides no ownership.
  */
-object NoOpOwnershipCollector : InvertOwnershipCollector() {
+object NoOpInvertOwnershipCollector : InvertOwnershipCollector {
 
   override fun collect(
     rootProjectDir: File,
     modulePath: ModulePath
-  ): OwnerInfo = OwnerInfo(OwnerInfo.UNOWNED)
+  ): OwnerName = "NoOp Invert Ownership"
+
+  override fun getOwnerNameForFile(
+    rootProjectDir: File,
+    fileInProject: File
+  ): OwnerName = "NoOp Invert Ownership"
 }

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/NoOpOwnershipCollector.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/NoOpOwnershipCollector.kt
@@ -3,13 +3,15 @@ package com.squareup.invert.internal
 import com.squareup.invert.InvertOwnershipCollector
 import com.squareup.invert.models.ModulePath
 import com.squareup.invert.models.OwnerInfo
+import java.io.File
 
 /**
  * Default implementation of [InvertOwnershipCollector] which provides no ownership.
  */
-object NoOpOwnershipCollector : InvertOwnershipCollector {
+object NoOpOwnershipCollector : InvertOwnershipCollector() {
+
   override fun collect(
-    rootProjectDir: String,
+    rootProjectDir: File,
     modulePath: ModulePath
   ): OwnerInfo = OwnerInfo(OwnerInfo.UNOWNED)
 }

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/models/CollectedOwnershipForProject.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/models/CollectedOwnershipForProject.kt
@@ -1,7 +1,7 @@
 package com.squareup.invert.internal.models
 
 import com.squareup.invert.models.ModulePath
-import com.squareup.invert.models.OwnerInfo
+import com.squareup.invert.models.OwnerName
 import kotlinx.serialization.Serializable
 
 /**
@@ -12,5 +12,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class CollectedOwnershipForProject(
   val path: ModulePath,
-  val ownerInfo: OwnerInfo,
+  val ownerName: OwnerName,
 )

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/report/js/InvertJsReportUtils.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/report/js/InvertJsReportUtils.kt
@@ -37,10 +37,8 @@ object InvertJsReportUtils {
     return OwnershipJsReportModel(
       modules = collectedOwners
         .associateBy { it.path }
-        .mapValues { it.value.ownerInfo.name },
-      teams = collectedOwners
-        .associateBy { it.ownerInfo.name }
-        .mapValues { it.value.ownerInfo }
+        .mapValues { it.value.ownerName },
+      teams = collectedOwners.map { it.ownerName }.toSet()
     )
   }
 

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/tasks/InvertCollectOwnershipTask.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/tasks/InvertCollectOwnershipTask.kt
@@ -20,6 +20,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import java.io.File
 
 /**
  * Using the specified [InvertOwnershipCollector], it collects ownership info for a given module.
@@ -46,7 +47,7 @@ internal abstract class InvertCollectOwnershipTask : DefaultTask() {
   @TaskAction
   internal fun execute() {
     val collectedOwnerInfo: OwnerInfo? =
-      ownershipCollector.collect(rootProjectDir.get(), targetModule.get())
+      ownershipCollector.collect(File(rootProjectDir.get()), targetModule.get())
 
     if (collectedOwnerInfo != null) {
       val projectOwnershipInfo = CollectedOwnershipForProject(

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/tasks/InvertCollectOwnershipTask.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/tasks/InvertCollectOwnershipTask.kt
@@ -46,20 +46,21 @@ internal abstract class InvertCollectOwnershipTask : DefaultTask() {
 
   @TaskAction
   internal fun execute() {
-    val ownerName: OwnerName = ownershipCollector.collect(File(rootProjectDir.get()), targetModule.get())
+    val gradleModuleDir = File(rootProjectDir.get(), targetModule.get().drop(1).replace(":", "/"))
+    val ownerName: OwnerName = ownershipCollector.collect(File(rootProjectDir.get()), gradleModuleDir)
 
-      val projectOwnershipInfo = CollectedOwnershipForProject(
-        path = targetModule.get(),
-        ownerName = ownerName
-      )
+    val projectOwnershipInfo = CollectedOwnershipForProject(
+      path = targetModule.get(),
+      ownerName = ownerName
+    )
 
-      InvertJsonReportWriter.writeJsonFile(
-        logger = invertLogger(),
-        jsonOutputFile = projectOwnershipJsonFile.get().asFile,
-        jsonFileKey = InvertPluginFileKey.OWNERS,
-        serializer = CollectedOwnershipForProject.serializer(),
-        value = projectOwnershipInfo
-      )
+    InvertJsonReportWriter.writeJsonFile(
+      logger = invertLogger(),
+      jsonOutputFile = projectOwnershipJsonFile.get().asFile,
+      jsonFileKey = InvertPluginFileKey.OWNERS,
+      serializer = CollectedOwnershipForProject.serializer(),
+      value = projectOwnershipInfo
+    )
   }
 
   fun setParams(

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/tasks/InvertCollectOwnershipTask.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/tasks/InvertCollectOwnershipTask.kt
@@ -11,7 +11,7 @@ import com.squareup.invert.internal.report.json.InvertJsonReportWriter
 import com.squareup.invert.logging.GradleInvertLogger
 import com.squareup.invert.logging.InvertLogger
 import com.squareup.invert.models.ModulePath
-import com.squareup.invert.models.OwnerInfo
+import com.squareup.invert.models.OwnerName
 import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.file.RegularFileProperty
@@ -46,13 +46,11 @@ internal abstract class InvertCollectOwnershipTask : DefaultTask() {
 
   @TaskAction
   internal fun execute() {
-    val collectedOwnerInfo: OwnerInfo? =
-      ownershipCollector.collect(File(rootProjectDir.get()), targetModule.get())
+    val ownerName: OwnerName = ownershipCollector.collect(File(rootProjectDir.get()), targetModule.get())
 
-    if (collectedOwnerInfo != null) {
       val projectOwnershipInfo = CollectedOwnershipForProject(
         path = targetModule.get(),
-        ownerInfo = collectedOwnerInfo
+        ownerName = ownerName
       )
 
       InvertJsonReportWriter.writeJsonFile(
@@ -62,9 +60,6 @@ internal abstract class InvertCollectOwnershipTask : DefaultTask() {
         serializer = CollectedOwnershipForProject.serializer(),
         value = projectOwnershipInfo
       )
-    } else {
-      logger.info("Could not determine Ownership for Module ${this.targetModule}")
-    }
   }
 
   fun setParams(

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/tasks/InvertCollectStatsTask.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/tasks/InvertCollectStatsTask.kt
@@ -1,7 +1,8 @@
 package com.squareup.invert.internal.tasks
 
-import com.squareup.invert.InvertExtension
 import com.squareup.invert.InvertCollectContext
+import com.squareup.invert.InvertExtension
+import com.squareup.invert.InvertOwnershipCollector
 import com.squareup.invert.StatCollector
 import com.squareup.invert.internal.InvertFileUtils
 import com.squareup.invert.internal.InvertFileUtils.addSlashAnd
@@ -49,6 +50,9 @@ internal abstract class InvertCollectStatsTask : DefaultTask() {
   @get:OutputFile
   abstract val projectBuildReportStatsFile: RegularFileProperty
 
+  @get:Internal
+  abstract var ownershipCollector: InvertOwnershipCollector
+
   private fun invertLogger(): InvertLogger = GradleInvertLogger(logger)
 
   @TaskAction
@@ -66,6 +70,7 @@ internal abstract class InvertCollectStatsTask : DefaultTask() {
                 gitCloneDir = File(rootProjectPath.get()),
                 modulePath = projectPath,
                 moduleDir = projectDir,
+                ownershipCollector = ownershipCollector,
               )
             )?.forEach { collectedStat ->
               val statKey = collectedStat.metadata.key
@@ -109,5 +114,6 @@ internal abstract class InvertCollectStatsTask : DefaultTask() {
     )
 
     statCollectors = extension.getStatCollectors().toList()
+    ownershipCollector = extension.getOwnershipCollector()
   }
 }

--- a/invert-gradle-plugin/src/test/kotlin/com/squareup/invert/internal/report/js/InvertJsReportUtilsTest.kt
+++ b/invert-gradle-plugin/src/test/kotlin/com/squareup/invert/internal/report/js/InvertJsReportUtilsTest.kt
@@ -1,0 +1,123 @@
+package com.squareup.invert.internal.report.js
+
+import com.squareup.invert.models.InvertSerialization.InvertJsonPrettyPrint
+import com.squareup.invert.models.ModulePath
+import com.squareup.invert.models.OwnerName
+import com.squareup.invert.models.Stat
+import com.squareup.invert.models.StatDataType
+import com.squareup.invert.models.StatKey
+import com.squareup.invert.models.StatMetadata
+import com.squareup.invert.models.js.OwnershipJsReportModel
+import com.squareup.invert.models.js.StatTotalAndMetadata
+import com.squareup.invert.models.js.StatsJsReportModel
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class InvertJsReportUtilsTest {
+
+  @Test
+  fun testComputeGlobalTotals() {
+
+    val MODULE_1 = "module1"
+    val MODULE_2 = "module2"
+    val OWNER_1 = "owner1"
+    val OWNER_2 = "owner2"
+
+    val codeRefStatInfo = StatMetadata(
+      key = "code_reference_stat",
+      description = "Code Reference Stat",
+      dataType = StatDataType.CODE_REFERENCES,
+    )
+
+    val numericStatInfo = StatMetadata(
+      key = "numeric_stat",
+      description = "Numeric Stat",
+      dataType = StatDataType.NUMERIC,
+    )
+
+    var codeReferenceCount = 0
+    fun generateCodeReference(ownerName: OwnerName?): Stat.CodeReferencesStat.CodeReference {
+      return Stat.CodeReferencesStat.CodeReference(
+        filePath = "code${codeReferenceCount++}.kt",
+        startLine = 1,
+        endLine = 100,
+        code = "code...",
+        owner = ownerName
+      )
+    }
+
+    val statsByModule = mutableMapOf<ModulePath, MutableMap<StatKey, Stat>>(
+      MODULE_1 to mutableMapOf(
+        codeRefStatInfo.key to Stat.CodeReferencesStat(
+          listOf(
+            generateCodeReference(null),
+            generateCodeReference(OWNER_1),
+            generateCodeReference(OWNER_2),
+          )
+        ),
+        numericStatInfo.key to Stat.NumericStat(42)
+      ),
+      MODULE_2 to mutableMapOf(
+        codeRefStatInfo.key to Stat.CodeReferencesStat(
+          listOf(
+            generateCodeReference(null),
+            generateCodeReference(null),
+            generateCodeReference(null),
+          )
+        ),
+        numericStatInfo.key to Stat.NumericStat(20)
+      )
+    )
+
+    val allProjectsStatsData = StatsJsReportModel(
+      statInfos = listOf(codeRefStatInfo, numericStatInfo).associateBy { it.key },
+      statsByModule = statsByModule
+    )
+    val collectedOwnershipInfo = OwnershipJsReportModel(
+      teams = setOf(OWNER_1, OWNER_2),
+      modules = mapOf(MODULE_1 to OWNER_1, MODULE_2 to OWNER_2)
+    )
+
+    val result: Map<String, StatTotalAndMetadata> =
+      InvertJsReportUtils.computeGlobalTotals(allProjectsStatsData, collectedOwnershipInfo)
+
+    assertEquals(
+      """
+{
+    "code_reference_stat": {
+        "metadata": {
+            "key": "code_reference_stat",
+            "description": "Code Reference Stat",
+            "dataType": "CODE_REFERENCES"
+        },
+        "total": 6,
+        "totalByOwner": {
+            "owner1": 2,
+            "owner2": 4
+        }
+    },
+    "numeric_stat": {
+        "metadata": {
+            "key": "numeric_stat",
+            "description": "Numeric Stat",
+            "dataType": "NUMERIC"
+        },
+        "total": 62,
+        "totalByOwner": {
+            "owner1": 42,
+            "owner2": 20
+        }
+    }
+}
+      """.trimIndent(),
+      InvertJsonPrettyPrint.encodeToString(
+        MapSerializer(String.serializer(), StatTotalAndMetadata.serializer()),
+        result,
+      ).also { json ->
+        println(json)
+      }
+    )
+  }
+}

--- a/invert-models/src/commonMain/kotlin/com/squareup/invert/models/OwnerInfo.kt
+++ b/invert-models/src/commonMain/kotlin/com/squareup/invert/models/OwnerInfo.kt
@@ -1,16 +1,9 @@
 package com.squareup.invert.models
 
-import kotlinx.serialization.Serializable
-
 /**
  * Shared model holding Ownership information.  In the future, this may hold more data
  * which is why it is a class and not just a primitive [String]
  */
-@Serializable
-data class OwnerInfo(
-  val name: OwnerName = UNOWNED,
-) {
-  companion object {
-    const val UNOWNED: OwnerName = "Unowned"
-  }
+object OwnerInfo {
+  const val UNOWNED: OwnerName = "Unowned"
 }

--- a/invert-models/src/commonMain/kotlin/com/squareup/invert/models/OwnerInfo.kt
+++ b/invert-models/src/commonMain/kotlin/com/squareup/invert/models/OwnerInfo.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class OwnerInfo(
-  val name: OwnerName,
+  val name: OwnerName = UNOWNED,
 ) {
   companion object {
     const val UNOWNED: OwnerName = "Unowned"

--- a/invert-models/src/commonMain/kotlin/com/squareup/invert/models/js/OwnershipJsReportModel.kt
+++ b/invert-models/src/commonMain/kotlin/com/squareup/invert/models/js/OwnershipJsReportModel.kt
@@ -10,6 +10,6 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class OwnershipJsReportModel(
-  val teams: Map<OwnerName, OwnerInfo>,
+  val teams: Set<OwnerName>,
   val modules: Map<ModulePath, OwnerName>
 )

--- a/invert-owners-github/src/main/kotlin/com/squareup/invert/owners/GitHubCodeOwnersInvertOwnershipCollector.kt
+++ b/invert-owners-github/src/main/kotlin/com/squareup/invert/owners/GitHubCodeOwnersInvertOwnershipCollector.kt
@@ -7,12 +7,24 @@ import com.github.pgreze.kowners.parseCodeOwners
 import com.squareup.invert.InvertOwnershipCollector
 import com.squareup.invert.models.ModulePath
 import com.squareup.invert.models.OwnerInfo
+import com.squareup.invert.models.OwnerName
 import java.io.File
 
 object GitHubCodeOwnersInvertOwnershipCollector : InvertOwnershipCollector {
-  override fun collect(rootProjectDir: String, modulePath: ModulePath): OwnerInfo {
 
-    val gitRoot = File(rootProjectDir).findGitRootPath()
+  override fun collect(
+    rootProjectDir: File,
+    modulePath: ModulePath
+  ): OwnerName {
+    val moduleDir = File(rootProjectDir, modulePath.drop(1).replace(":", "/"))
+    return getOwnerNameForFile(rootProjectDir, moduleDir)
+  }
+
+  override fun getOwnerNameForFile(
+    rootProjectDir: File,
+    fileInProject: File
+  ): OwnerName {
+    val gitRoot = rootProjectDir.findGitRootPath()
       ?: throw IllegalStateException("This is not a Git Repository.  Could not locate the .git folder at the root.")
 
     val CODEOWNERS_FILES = gitRoot.findCodeOwnerLocations()
@@ -24,22 +36,15 @@ object GitHubCodeOwnersInvertOwnershipCollector : InvertOwnershipCollector {
       .forEach { allLines.addAll(it.readLines()) }
 
     val ownersResolver by lazy {
-      OwnersResolver(
-        allLines.parseCodeOwners()
-      )
+      OwnersResolver(allLines.parseCodeOwners())
     }
 
-    return OwnerInfo(
-      if (allLines.isEmpty()) {
-        "No CODEOWNERS File at ${CODEOWNERS_FILES.map { it.path }}"
-      } else {
-        // TODO FIX THIS COMPUTATION
-        val projectDir = File(rootProjectDir, modulePath.drop(1).replace(":", "/"))
-        val relativePath = projectDir.absolutePath.replace(gitRoot.absolutePath, "")
-        val owners = ownersResolver
-          .resolveOwnership(relativePath)
-        owners?.joinToString("/n") ?: OwnerInfo.UNOWNED
-      }
-    )
+    return if (allLines.isEmpty()) {
+      "No CODEOWNERS File at ${CODEOWNERS_FILES.map { it.path }}"
+    } else {
+      // TODO FIX THIS COMPUTATION
+      val owners = ownersResolver.resolveOwnership(fileInProject.relativeTo(rootProjectDir).path)
+      owners?.joinToString("/n") ?: OwnerInfo.UNOWNED
+    }
   }
 }

--- a/invert-owners-github/src/main/kotlin/com/squareup/invert/owners/GitHubCodeOwnersInvertOwnershipCollector.kt
+++ b/invert-owners-github/src/main/kotlin/com/squareup/invert/owners/GitHubCodeOwnersInvertOwnershipCollector.kt
@@ -5,26 +5,16 @@ import com.github.pgreze.kowners.findCodeOwnerLocations
 import com.github.pgreze.kowners.findGitRootPath
 import com.github.pgreze.kowners.parseCodeOwners
 import com.squareup.invert.InvertOwnershipCollector
-import com.squareup.invert.models.ModulePath
 import com.squareup.invert.models.OwnerInfo
 import com.squareup.invert.models.OwnerName
 import java.io.File
 
 object GitHubCodeOwnersInvertOwnershipCollector : InvertOwnershipCollector {
-
   override fun collect(
-    rootProjectDir: File,
-    modulePath: ModulePath
+    gitRootDir: File,
+    fileWithOwnership: File
   ): OwnerName {
-    val moduleDir = File(rootProjectDir, modulePath.drop(1).replace(":", "/"))
-    return getOwnerNameForFile(rootProjectDir, moduleDir)
-  }
-
-  override fun getOwnerNameForFile(
-    rootProjectDir: File,
-    fileInProject: File
-  ): OwnerName {
-    val gitRoot = rootProjectDir.findGitRootPath()
+    val gitRoot = gitRootDir.findGitRootPath()
       ?: throw IllegalStateException("This is not a Git Repository.  Could not locate the .git folder at the root.")
 
     val CODEOWNERS_FILES = gitRoot.findCodeOwnerLocations()
@@ -43,7 +33,7 @@ object GitHubCodeOwnersInvertOwnershipCollector : InvertOwnershipCollector {
       "No CODEOWNERS File at ${CODEOWNERS_FILES.map { it.path }}"
     } else {
       // TODO FIX THIS COMPUTATION
-      val owners = ownersResolver.resolveOwnership(fileInProject.relativeTo(rootProjectDir).path)
+      val owners = ownersResolver.resolveOwnership(fileWithOwnership.relativeTo(gitRootDir).path)
       owners?.joinToString("/n") ?: OwnerInfo.UNOWNED
     }
   }

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/ReportDataRepo.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/ReportDataRepo.kt
@@ -112,7 +112,7 @@ class ReportDataRepo(
   val allOwnerNames: Flow<List<String>?> = collectedDataRepo.ownersInfo
     .mapLatest { ownersInfo ->
       computeMeasureDuration("allOwners") {
-        ownersInfo?.teams?.keys?.sorted()
+        ownersInfo?.teams?.sorted()
       }
     }
 


### PR DESCRIPTION
Ownership Related:
- Ownership defaults to "Unowned" now.
- Removed wrapper data class of `OwnerInfo()` which was just adding complexity.
- Using files instead of paths for explicitness
- Updated Ownership collector to just take `File` objects.
- Updated the `InvertCollectContext` to include the `InvertOwnershipCollector` instance.

Other:
- Github Action Artifact Upload version bump
- Updated stat computation to be more focused on Owner and fallback to Module Owner to honor ownership in code references.  This was a need in some use cases and reflects in more accurate data.  Added unit tests for this.
- Cleaned up dead code paths on the `CodeOwners` report page.