### PR TITLE
Fixing navigation to stop adding on random "#" to the URL

### DIFF
--- a/invert-report/src/jsMain/kotlin/MainComposables.kt
+++ b/invert-report/src/jsMain/kotlin/MainComposables.kt
@@ -22,58 +22,61 @@ import ui.NavBarComposable
 
 
 fun invertComposeMain(
-    initialRoute: NavRoute,
-    routeManager: NavRouteManager,
-    navRouteRepo: NavRouteRepo,
-    reportDataRepo: ReportDataRepo,
-    navGroupsRepo: NavGroupsRepo,
+  initialRoute: NavRoute,
+  routeManager: NavRouteManager,
+  navRouteRepo: NavRouteRepo,
+  reportDataRepo: ReportDataRepo,
+  navGroupsRepo: NavGroupsRepo,
 ) {
-    setupNavigation(routeManager, navRouteRepo)
+  setupNavigation(routeManager, navRouteRepo)
 
-    renderComposable(rootElementId = "navigation") {
-        LeftNavigationComposable(initialRoute, navRouteRepo, reportDataRepo, navGroupsRepo)
+  renderComposable(rootElementId = "navigation") {
+    LeftNavigationComposable(initialRoute, navRouteRepo, reportDataRepo, navGroupsRepo)
+  }
+
+  renderComposable(rootElementId = "main_content") {
+    MainContentComposable(routeManager, navRouteRepo)
+  }
+
+  renderComposable(rootElementId = "navbar_content") {
+    NavBarComposable(RemoteJsLoadingProgress.awaitingResults)
+  }
+
+  renderComposable(rootElementId = "navbar_title") {
+    val reportMetadata by reportDataRepo.reportMetadata.collectAsState(null)
+
+    Text("\uD83D\uDD03 Invert Report")
+    reportMetadata?.let { metadata ->
+      Text(" for ")
+      A(href = metadata.remoteRepoUrl, attrs = { target(Blank) }) {
+        Text(metadata.remoteRepoUrl.substringAfter("//").substringAfter("/"))
+      }
     }
-
-    renderComposable(rootElementId = "main_content") {
-        MainContentComposable(routeManager, navRouteRepo)
-    }
-
-    renderComposable(rootElementId = "navbar_content") {
-        NavBarComposable(RemoteJsLoadingProgress.awaitingResults)
-    }
-
-    renderComposable(rootElementId = "navbar_title") {
-        val reportMetadata by reportDataRepo.reportMetadata.collectAsState(null)
-
-        Text("\uD83D\uDD03 Invert Report")
-        reportMetadata?.let { metadata ->
-            Text(" for ")
-            A(href = metadata.remoteRepoUrl, attrs = { target(Blank) }) {
-                Text(metadata.remoteRepoUrl.substringAfter("//").substringAfter("/"))
-            }
-        }
-    }
+  }
 }
 
 @OptIn(DelicateCoroutinesApi::class)
 fun setupNavigation(routeManager: NavRouteManager, navRouteRepo: NavRouteRepo) {
-    val javaScriptNavigationAndHistory = JavaScriptNavigationAndHistory(routeManager, navRouteRepo)
-    // Update Route on Every Change
-    navRouteRepo.navRoute.onEach {
-        JavaScriptNavigationAndHistory.setUrlFromNavRoute(it)
-    }.launchIn(GlobalScope)
+  val javaScriptNavigationAndHistory = JavaScriptNavigationAndHistory(routeManager, navRouteRepo)
+  // Update Route on Every Change
+  navRouteRepo.navRoute.onEach { navRouteEvent ->
+    JavaScriptNavigationAndHistory.setUrlFromNavRoute(
+      navRoute = navRouteEvent.navRoute,
+      pushOrReplaceState = navRouteEvent.pushOrReplaceState,
+    )
+  }.launchIn(GlobalScope)
 
-    // Register for Browser Back/Forward Button Events
-    javaScriptNavigationAndHistory.registerForPopstate()
+  // Register for Browser Back/Forward Button Events
+  javaScriptNavigationAndHistory.registerForPopstate()
 }
 
 @Composable
 fun MainContentComposable(
-    navRouteManager: NavRouteManager,
-    navRouteRepo: NavRouteRepo
+  navRouteManager: NavRouteManager,
+  navRouteRepo: NavRouteRepo
 ) {
-    val navRouteCollected = navRouteRepo.navRoute.collectAsState(null)
-    navRouteCollected.value?.let { navRoute ->
-        navRouteManager.renderContentForRoute(navRoute)
-    }
+  val navRouteCollected = navRouteRepo.navRoute.collectAsState(null)
+  navRouteCollected.value?.let { navRouteEvent ->
+    navRouteManager.renderContentForRoute(navRouteEvent.navRoute)
+  }
 }

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/ReportDataRepo.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/ReportDataRepo.kt
@@ -1,7 +1,7 @@
 package com.squareup.invert.common
 
 import com.squareup.invert.common.PerformanceAndTiming.computeMeasureDuration
-import com.squareup.invert.common.navigation.NavRoute
+import com.squareup.invert.common.navigation.NavRouteRepo
 import com.squareup.invert.common.pages.InvertedDependenciesNavRoute
 import com.squareup.invert.common.utils.DependencyComputations
 import com.squareup.invert.models.ConfigurationName
@@ -28,7 +28,7 @@ import kotlinx.coroutines.flow.mapLatest
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class ReportDataRepo(
-  private val navRoute: Flow<NavRoute>,
+  private val navRoute: Flow<NavRouteRepo.NavChangeEvent>,
   private val collectedDataRepo: CollectedDataRepo,
 ) {
 

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/navigation/NavRouteRepo.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/navigation/NavRouteRepo.kt
@@ -1,5 +1,6 @@
 package com.squareup.invert.common.navigation
 
+import history.PushOrReplaceState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 
@@ -8,11 +9,20 @@ import kotlinx.coroutines.flow.MutableStateFlow
  */
 class NavRouteRepo(initialRoute: NavRoute) {
 
-  private val _navRoute = MutableStateFlow(initialRoute)
+  private val _navRoute = MutableStateFlow(NavChangeEvent(initialRoute))
 
-  val navRoute: Flow<NavRoute> = _navRoute
+  val navRoute: Flow<NavChangeEvent> = _navRoute
 
   fun updateNavRoute(navRoute: NavRoute) {
-    this._navRoute.tryEmit(navRoute)
+    this._navRoute.tryEmit(NavChangeEvent(navRoute))
   }
+
+  fun replaceNavRoute(navRoute: NavRoute) {
+    this._navRoute.tryEmit(NavChangeEvent(navRoute, PushOrReplaceState.REPLACE))
+  }
+
+  class NavChangeEvent(
+    val navRoute: NavRoute,
+    val pushOrReplaceState: PushOrReplaceState = PushOrReplaceState.PUSH
+  )
 }

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/navigation/NavRouteRepo.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/navigation/NavRouteRepo.kt
@@ -9,20 +9,31 @@ import kotlinx.coroutines.flow.MutableStateFlow
  */
 class NavRouteRepo(initialRoute: NavRoute) {
 
-  private val _navRoute = MutableStateFlow(NavChangeEvent(initialRoute))
+  private val _navRoute = MutableStateFlow(
+    NavChangeEvent(
+      initialRoute,
+      PushOrReplaceState.PUSH
+    )
+  )
 
   val navRoute: Flow<NavChangeEvent> = _navRoute
 
-  fun updateNavRoute(navRoute: NavRoute) {
-    this._navRoute.tryEmit(NavChangeEvent(navRoute))
+  /**
+   * Adds new item to browser history stack.
+   */
+  fun pushNavRoute(navRoute: NavRoute) {
+    this._navRoute.tryEmit(NavChangeEvent(navRoute, PushOrReplaceState.PUSH))
   }
 
+  /**
+   * Updates/Replaces the URL in the browser history, but does NOT add a new item to browser history stack.
+   */
   fun replaceNavRoute(navRoute: NavRoute) {
     this._navRoute.tryEmit(NavChangeEvent(navRoute, PushOrReplaceState.REPLACE))
   }
 
   class NavChangeEvent(
     val navRoute: NavRoute,
-    val pushOrReplaceState: PushOrReplaceState = PushOrReplaceState.PUSH
+    val pushOrReplaceState: PushOrReplaceState,
   )
 }

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/navigation/routes/BaseNavRoute.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/navigation/routes/BaseNavRoute.kt
@@ -21,8 +21,4 @@ abstract class BaseNavRoute(
       }
     }
   }
-
-  fun toQueryString(): String {
-    return toSearchParams().map { (key, value) -> "$key=$value" }.joinToString("&")
-  }
 }

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/navigation/routes/NavRouteExt.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/navigation/routes/NavRouteExt.kt
@@ -1,0 +1,7 @@
+package com.squareup.invert.common.navigation.routes
+
+import com.squareup.invert.common.navigation.NavRoute
+
+fun NavRoute.toQueryString(): String {
+  return "?" + toSearchParams().map { (key, value) -> "$key=$value" }.joinToString("&")
+}

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/AllModulesReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/AllModulesReportPage.kt
@@ -104,10 +104,10 @@ fun ModulesComposable(
       query = query ?: "",
       placeholderText = "Module Query...",
     ) {
-      navRouteRepo.updateNavRoute(modulesNavRoute.copy(query = it))
+      navRouteRepo.replaceNavRoute(modulesNavRoute.copy(query = it))
     }
     ModulesByNameComposable(allModulesWithOwnerMatchingQuery) {
-      navRouteRepo.updateNavRoute(ModuleDetailNavRoute(it))
+      navRouteRepo.pushNavRoute(ModuleDetailNavRoute(it))
     }
   })
   BootstrapTabPane(

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/AllStatsReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/AllStatsReportPage.kt
@@ -101,7 +101,7 @@ fun AllStatsComposable(
     val statsOfType = statTotals.statTotals.values.filter { it.metadata.dataType == statDataType }
     if (statsOfType.isNotEmpty()) {
       H1 { Text("${statDataType.displayName} Stats") }
-      StatTiles(statsOfType, navRouteRepo::updateNavRoute)
+      StatTiles(statsOfType, navRouteRepo::pushNavRoute)
     }
   }
 
@@ -129,7 +129,7 @@ fun AllStatsComposable(
     onItemClickCallback = { cellValues ->
       val statKey = cellValues[0]
       val statDataType = StatDataType.fromString(cellValues[2])
-      navRouteRepo.updateNavRoute(
+      navRouteRepo.pushNavRoute(
         if (statDataType == StatDataType.CODE_REFERENCES) {
           CodeReferencesNavRoute(
             statKey = statKey,
@@ -149,7 +149,7 @@ fun AllStatsComposable(
     "View All, Grouped By Module",
     BootstrapButtonType.SECONDARY,
     onClick = {
-      navRouteRepo.updateNavRoute(
+      navRouteRepo.pushNavRoute(
         StatDetailNavRoute(
           pluginIds = listOf(),
           statKeys = statInfos.map { it.metadata.key }

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/AnnotationProcessorsReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/AnnotationProcessorsReportPage.kt
@@ -109,7 +109,7 @@ fun AnnotationProcessorsComposable(
                         types = listOf(String::class),
                         maxResultsLimitConstant = PagingConstants.MAX_RESULTS
                     ) {
-                        navRouteRepo.updateNavRoute(
+                        navRouteRepo.pushNavRoute(
                             ModuleDetailNavRoute(
                                 path = it[0]
                             )

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/ArtifactDetailReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/ArtifactDetailReportPage.kt
@@ -118,7 +118,7 @@ fun ArtifactDetailComposable(
             types = listOf(String::class, String::class),
             maxResultsLimitConstant = PagingConstants.MAX_RESULTS,
             onItemClickCallback = {
-                navRouteRepo.updateNavRoute(ModuleDetailNavRoute(it[0]))
+                navRouteRepo.pushNavRoute(ModuleDetailNavRoute(it[0]))
             }
         )
     }

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/ArtifactsReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/ArtifactsReportPage.kt
@@ -121,7 +121,7 @@ fun ArtifactsComposable(
                 navRoute.query ?: "",
                 "Search For Artifact..."
             ) {
-                navRouteRepo.updateNavRoute(
+                navRouteRepo.pushNavRoute(
                     ArtifactsNavRoute(it)
                 )
             }
@@ -140,7 +140,7 @@ fun ArtifactsComposable(
                     )
                 ),
                 onClick = { label, value ->
-                    navRouteRepo.updateNavRoute(
+                    navRouteRepo.pushNavRoute(
                         ArtifactsNavRoute(
                             query = "$label:"
                         )
@@ -169,7 +169,7 @@ fun ArtifactsComposable(
         types = artifactsMatchingQuery.map { String::class },
         maxResultsLimitConstant = MAX_RESULTS,
         onItemClickCallback = {
-            navRouteRepo.updateNavRoute(
+            navRouteRepo.pushNavRoute(
                 ArtifactDetailNavRoute(
                     group = it[0],
                     artifact = it[1],

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/CodeReferencesReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/CodeReferencesReportPage.kt
@@ -160,7 +160,7 @@ fun CodeReferencesComposable(
   if (currentStatMetadata == null) {
     H1 { Text("No stat with key '${codeReferencesNavRoute.statKey}' found") }
     BootstrapButton("View All Stats") {
-      navRouteRepo.updateNavRoute(AllStatsNavRoute())
+      navRouteRepo.pushNavRoute(AllStatsNavRoute())
     }
     return
   }
@@ -183,7 +183,7 @@ fun CodeReferencesComposable(
             Li {
               NavRouteLink(
                 StatDetailNavRoute(statKeys = listOf(statKey)),
-                navRouteRepo::updateNavRoute
+                navRouteRepo::pushNavRoute
               ) {
                 Text("View Grouped by Module")
               }
@@ -198,7 +198,7 @@ fun CodeReferencesComposable(
                       true
                     }
                   ),
-                  navRouteRepo::updateNavRoute
+                  navRouteRepo::pushNavRoute
                 ) {
                   if (codeReferencesNavRoute.chart == true) {
                     Text("Hide Chart")
@@ -217,7 +217,7 @@ fun CodeReferencesComposable(
                     true
                   }
                 ),
-                navRouteRepo::updateNavRoute,
+                navRouteRepo::pushNavRoute,
               ) {
                 if (codeReferencesNavRoute.treemap == true) {
                   Text("Hide Treemap")
@@ -232,7 +232,7 @@ fun CodeReferencesComposable(
                   statKey = codeReferencesNavRoute.statKey,
                   owner = codeReferencesNavRoute.owner,
                 ),
-                navRouteRepo::updateNavRoute
+                navRouteRepo::pushNavRoute
               ) {
                 Text("View Owner Breakdown")
               }
@@ -354,7 +354,7 @@ fun CodeReferencesComposable(
             )
           }.sortedBy { it.displayText }
         ) {
-          navRouteRepo.updateNavRoute(
+          navRouteRepo.pushNavRoute(
             codeReferencesNavRoute.copy(
               owner = it?.value,
             )
@@ -377,7 +377,7 @@ fun CodeReferencesComposable(
             )
           }.sortedBy { it.displayText }
         ) {
-          navRouteRepo.updateNavRoute(
+          navRouteRepo.pushNavRoute(
             codeReferencesNavRoute.copy(
               module = it?.value
             )

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/CodeReferencesReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/CodeReferencesReportPage.kt
@@ -38,6 +38,7 @@ import ui.BootstrapRow
 import ui.BootstrapSelectDropdown
 import ui.BootstrapSelectOption
 import ui.BootstrapTable
+import ui.NavRouteLink
 import kotlin.reflect.KClass
 
 data class CodeReferencesNavRoute(
@@ -177,33 +178,29 @@ fun CodeReferencesComposable(
       }
     }
     BootstrapColumn(4) {
-      codeReferencesNavRoute.statKey?.let { statKey ->
+      codeReferencesNavRoute.statKey.let { statKey ->
         P {
           Ul {
             Li {
-              A("#", {
-                onClick {
-                  navRouteRepo.updateNavRoute(StatDetailNavRoute(statKeys = listOf(statKey)))
-                }
-              }) {
+              NavRouteLink(
+                StatDetailNavRoute(statKeys = listOf(statKey)),
+                navRouteRepo::updateNavRoute
+              ) {
                 Text("View Grouped by Module")
               }
             }
             if (historicalData.size > 1) {
               Li {
-                A("#", {
-                  onClick {
-                    navRouteRepo.updateNavRoute(
-                      codeReferencesNavRoute.copy(
-                        chart = if (codeReferencesNavRoute.chart != null) {
-                          !codeReferencesNavRoute.chart
-                        } else {
-                          true
-                        }
-                      )
-                    )
-                  }
-                }) {
+                NavRouteLink(
+                  codeReferencesNavRoute.copy(
+                    chart = if (codeReferencesNavRoute.chart != null) {
+                      !codeReferencesNavRoute.chart
+                    } else {
+                      true
+                    }
+                  ),
+                  navRouteRepo::updateNavRoute
+                ) {
                   if (codeReferencesNavRoute.chart == true) {
                     Text("Hide Chart")
                   } else {

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/CodeReferencesReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/CodeReferencesReportPage.kt
@@ -22,7 +22,6 @@ import com.squareup.invert.models.ModulePath
 import com.squareup.invert.models.OwnerName
 import com.squareup.invert.models.StatKey
 import com.squareup.invert.models.StatMetadata
-import org.jetbrains.compose.web.dom.A
 import org.jetbrains.compose.web.dom.H1
 import org.jetbrains.compose.web.dom.H3
 import org.jetbrains.compose.web.dom.H4
@@ -210,19 +209,16 @@ fun CodeReferencesComposable(
               }
             }
             Li {
-              A("#", {
-                onClick {
-                  navRouteRepo.updateNavRoute(
-                    codeReferencesNavRoute.copy(
-                      treemap = if (codeReferencesNavRoute.treemap != null) {
-                        !codeReferencesNavRoute.treemap
-                      } else {
-                        true
-                      }
-                    )
-                  )
-                }
-              }) {
+              NavRouteLink(
+                codeReferencesNavRoute.copy(
+                  treemap = if (codeReferencesNavRoute.treemap != null) {
+                    !codeReferencesNavRoute.treemap
+                  } else {
+                    true
+                  }
+                ),
+                navRouteRepo::updateNavRoute,
+              ) {
                 if (codeReferencesNavRoute.treemap == true) {
                   Text("Hide Treemap")
                 } else {
@@ -231,16 +227,13 @@ fun CodeReferencesComposable(
               }
             }
             Li {
-              A("#", {
-                onClick {
-                  navRouteRepo.updateNavRoute(
-                    OwnerBreakdownNavRoute(
-                      statKey = codeReferencesNavRoute.statKey,
-                      owner = codeReferencesNavRoute.owner,
-                    )
-                  )
-                }
-              }) {
+              NavRouteLink(
+                OwnerBreakdownNavRoute(
+                  statKey = codeReferencesNavRoute.statKey,
+                  owner = codeReferencesNavRoute.owner,
+                ),
+                navRouteRepo::updateNavRoute
+              ) {
                 Text("View Owner Breakdown")
               }
             }
@@ -268,7 +261,6 @@ fun CodeReferencesComposable(
   }
 
   val statKey = codeReferencesNavRoute.statKey
-
 
   val statsForKey: MutableList<ModuleOwnerAndCodeReference>? by reportDataRepo.statsForKey(statKey)
     .collectAsState(null)

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/ConfigurationDetailReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/ConfigurationDetailReportPage.kt
@@ -97,7 +97,7 @@ fun ConfigurationDetailComposable(
         types = listOf(String::class),
         maxResultsLimitConstant = MAX_RESULTS,
         onItemClickCallback = {
-            navRouteRepo.updateNavRoute(
+            navRouteRepo.pushNavRoute(
                 ModuleDetailNavRoute(
                     it[0]
                 )

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/ConfigurationsReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/ConfigurationsReportPage.kt
@@ -60,7 +60,7 @@ fun ConfigurationsComposable(
     BootstrapRow {
         BootstrapColumn(12) {
             BootstrapClickableList("Analyzed Configurations", list, MAX_RESULTS) { item ->
-                navRouteRepo.updateNavRoute(ConfigurationDetailNavRoute(item))
+                navRouteRepo.pushNavRoute(ConfigurationDetailNavRoute(item))
             }
         }
     }

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/DependencyDiffReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/DependencyDiffReportPage.kt
@@ -139,19 +139,19 @@ fun ModuleDependencyDiffComposable(
                 placeholderText = "Module A...",
                 dataListId = ALL_MODULES_DATALIST_ID,
             ) {
-                navRouteRepo.updateNavRoute(navRoute.copy(moduleA = it))
+                navRouteRepo.replaceNavRoute(navRoute.copy(moduleA = it))
             }
             BootstrapSearchBox(
                 query = navRoute.configurationA ?: "",
                 placeholderText = "Configuration A...",
                 dataListId = MODULE_A_CONFIGURATIONS_DATALIST,
             ) {
-                navRouteRepo.updateNavRoute(navRoute.copy(configurationA = it))
+                navRouteRepo.replaceNavRoute(navRoute.copy(configurationA = it))
             }
         }
         BootstrapColumn(2) {
             BootstrapButton("↔️") {
-                navRouteRepo.updateNavRoute(
+                navRouteRepo.replaceNavRoute(
                     navRoute.copy(
                         moduleA = navRoute.moduleB,
                         moduleB = navRoute.moduleA,
@@ -167,23 +167,23 @@ fun ModuleDependencyDiffComposable(
                 placeholderText = "Module B...",
                 dataListId = ALL_MODULES_DATALIST_ID,
             ) {
-                navRouteRepo.updateNavRoute(navRoute.copy(moduleB = it))
+                navRouteRepo.replaceNavRoute(navRoute.copy(moduleB = it))
             }
             BootstrapSearchBox(
                 query = navRoute.configurationB ?: "",
                 placeholderText = "Configuration B...",
                 dataListId = MODULE_A_CONFIGURATIONS_DATALIST,
             ) {
-                navRouteRepo.updateNavRoute(navRoute.copy(configurationB = it))
+                navRouteRepo.replaceNavRoute(navRoute.copy(configurationB = it))
             }
         }
     }
 
     BootstrapSettingsCheckbox("Include Artifacts", navRoute.includeArtifacts) {
-        navRouteRepo.updateNavRoute(navRoute.copy(includeArtifacts = it))
+        navRouteRepo.replaceNavRoute(navRoute.copy(includeArtifacts = it))
     }
     BootstrapSettingsCheckbox("Show Matching", navRoute.showMatching) {
-        navRouteRepo.updateNavRoute(navRoute.copy(showMatching = it))
+        navRouteRepo.replaceNavRoute(navRoute.copy(showMatching = it))
     }
 
     Br()

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/GradlePluginsReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/GradlePluginsReportPage.kt
@@ -87,14 +87,14 @@ fun PluginsComposable(
         navRoute.query ?: "",
         "Search For Artifact..."
     ) {
-        navRouteRepo.updateNavRoute(
+        navRouteRepo.pushNavRoute(
             ArtifactsNavRoute(it)
         )
     }
     BootstrapRow {
         BootstrapColumn(6) {
             BootstrapClickableList("Plugins", allPluginIds!!, MAX_RESULTS) { gradlePluginId ->
-                navRouteRepo.updateNavRoute(PluginDetailNavRoute(gradlePluginId))
+                navRouteRepo.pushNavRoute(PluginDetailNavRoute(gradlePluginId))
             }
         }
         BootstrapColumn(6) {
@@ -110,7 +110,7 @@ fun PluginsComposable(
                     )
                 ),
                 onClick = { label, value ->
-                    navRouteRepo.updateNavRoute(
+                    navRouteRepo.pushNavRoute(
                         PluginDetailNavRoute(
                             pluginId = label,
                         )

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/HomeReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/HomeReportPage.kt
@@ -120,25 +120,25 @@ fun HomeComposable(
       moduleCount,
       AllModulesReportPage.navPage,
       AllModulesNavRoute(),
-    ) { navRouteRepo.updateNavRoute(it) }
+    ) { navRouteRepo.pushNavRoute(it) }
 
     HomeCountComposable(
       artifactCount,
       ArtifactsReportPage.navPage,
       AllModulesNavRoute()
-    ) { navRouteRepo.updateNavRoute(ArtifactsNavRoute()) }
+    ) { navRouteRepo.pushNavRoute(ArtifactsNavRoute()) }
 
     HomeCountComposable(
       pluginIdsCount,
       GradlePluginsReportPage.navPage,
       AllModulesNavRoute()
-    ) { navRouteRepo.updateNavRoute(GradlePluginsNavRoute(null)) }
+    ) { navRouteRepo.pushNavRoute(GradlePluginsNavRoute(null)) }
 
     HomeCountComposable(
       ownersCount,
       OwnersReportPage.navPage,
       AllModulesNavRoute()
-    ) { navRouteRepo.updateNavRoute(OwnersNavRoute) }
+    ) { navRouteRepo.pushNavRoute(OwnersNavRoute) }
 
     statTotals.statTotals.values.forEach { statTotalAndMetadata ->
       BootstrapColumn(3) {
@@ -159,7 +159,7 @@ fun HomeComposable(
           }
           A(href = destRoute.toQueryString(), {
             onClick {
-              navRouteRepo.updateNavRoute(destRoute)
+              navRouteRepo.pushNavRoute(destRoute)
             }
           }) {
             Small {
@@ -177,7 +177,7 @@ fun HomeComposable(
     "View All",
     BootstrapButtonType.PRIMARY,
     onClick = {
-      navRouteRepo.updateNavRoute(
+      navRouteRepo.pushNavRoute(
         AllStatsNavRoute()
       )
     }

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/InvertedDependenciesReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/InvertedDependenciesReportPage.kt
@@ -144,7 +144,7 @@ fun InverteDependenciesComposable(
                             Text("or... ")
                             Br()
                             BootstrapButton("Start by Searching Everything") {
-                                navRouteRepo.updateNavRoute(
+                                navRouteRepo.pushNavRoute(
                                     InvertedDependenciesNavRoute(
                                         pluginGroupByFilter = allPluginIds!!,
                                         configurations = allConfigurationNames!!.toList(),
@@ -158,7 +158,7 @@ fun InverteDependenciesComposable(
                     TitleRow("Inverted Dependency Search (Grouped By Plugin Type)")
                     val query by reportDataRepo.moduleQuery.collectAsState(null)
                     BootstrapSearchBox(query ?: "", "Search For Module...") {
-                        navRouteRepo.updateNavRoute(
+                        navRouteRepo.replaceNavRoute(
                             navRoute.copy(
                                 moduleQuery = it
                             )
@@ -172,7 +172,7 @@ fun InverteDependenciesComposable(
                                 "Matching ${matching?.size} of $totalCount",
                                 matching ?: listOf(),
                                 onItemClick = {
-                                    navRouteRepo.updateNavRoute(
+                                    navRouteRepo.pushNavRoute(
                                         navRoute.copy(
                                             moduleQuery = it
                                         )
@@ -218,12 +218,12 @@ fun SettingsComposable(
             BootstrapColumn(6) {
                 H5 { Text("Configurations") }
                 BootstrapButton("Select All") {
-                    navRouteRepo.updateNavRoute(
+                    navRouteRepo.pushNavRoute(
                         invertedDependenciesNavRoute.copy(configurations = allConfigurationNames)
                     )
                 }
                 BootstrapButton("Unselect All") {
-                    navRouteRepo.updateNavRoute(
+                    navRouteRepo.pushNavRoute(
                         invertedDependenciesNavRoute.copy(configurations = listOf())
                     )
                 }
@@ -232,7 +232,7 @@ fun SettingsComposable(
                         labelText = configurationName,
                         initialIsChecked = invertedDependenciesNavRoute.configurations.contains(configurationName)
                     ) { shouldAdd ->
-                        navRouteRepo.updateNavRoute(
+                        navRouteRepo.pushNavRoute(
                             invertedDependenciesNavRoute.copy(
                                 configurations = invertedDependenciesNavRoute.configurations
                                     .toMutableList()
@@ -250,14 +250,14 @@ fun SettingsComposable(
             BootstrapColumn(6) {
                 H5 { Text("Plugins") }
                 BootstrapButton("Select All") {
-                    navRouteRepo.updateNavRoute(
+                    navRouteRepo.pushNavRoute(
                         invertedDependenciesNavRoute.copy(
                             pluginGroupByFilter = allPluginIds ?: listOf()
                         )
                     )
                 }
                 BootstrapButton("Unselect All") {
-                    navRouteRepo.updateNavRoute(
+                    navRouteRepo.pushNavRoute(
                         invertedDependenciesNavRoute.copy(
                             pluginGroupByFilter = listOf()
                         )
@@ -269,7 +269,7 @@ fun SettingsComposable(
                         labelText = gradlePluginId,
                         initialIsChecked = groupByFilterItems.contains(gradlePluginId)
                     ) { shouldAdd ->
-                        navRouteRepo.updateNavRoute(
+                        navRouteRepo.pushNavRoute(
                             invertedDependenciesNavRoute.copy(
                                 pluginGroupByFilter = invertedDependenciesNavRoute.pluginGroupByFilter.toMutableList()
                                     .apply {

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/InvertedDependenciesReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/InvertedDependenciesReportPage.kt
@@ -111,6 +111,11 @@ fun InverteDependenciesComposable(
         BootstrapLoadingMessageWithSpinner()
         return
     }
+    println("1")
+    if (allConfigurationNames!!.isEmpty()) {
+        H1 { Text("No analyzed configurations found.") }
+        return
+    }
 
     BootstrapTabPane(
         listOf(

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/KotlinCompilerPluginsReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/KotlinCompilerPluginsReportPage.kt
@@ -107,7 +107,7 @@ fun KotlinCompilerPluginsComposable(
                         types = listOf(String::class),
                         maxResultsLimitConstant = PagingConstants.MAX_RESULTS
                     ) {
-                        navRouteRepo.updateNavRoute(
+                        navRouteRepo.pushNavRoute(
                             ModuleDetailNavRoute(
                                 path = it[0]
                             )

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/ModuleDependencyGraphReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/ModuleDependencyGraphReportPage.kt
@@ -46,217 +46,222 @@ import kotlin.random.Random
 import kotlin.reflect.KClass
 
 data class ModuleDependencyGraphNavRoute(
-    val module: String? = null,
-    val configuration: String? = null,
+  val module: String? = null,
+  val configuration: String? = null,
 ) : BaseNavRoute(ModuleDependencyGraphReportPage.navPage) {
 
-    override fun toSearchParams(): Map<String, String> = toParamsWithOnlyPageId(this)
-        .also { params ->
-            module?.let {
-                params[MODULE_PARAM] = module
-            }
-            configuration?.let {
-                params[CONFIGURATION_PARAM] = configuration
-            }
-        }
-
-    companion object {
-
-        private const val MODULE_PARAM = "module"
-        private const val CONFIGURATION_PARAM = "configuration"
-
-        fun parser(params: Map<String, String?>): ModuleDependencyGraphNavRoute {
-            return ModuleDependencyGraphNavRoute(
-                module = params[MODULE_PARAM],
-                configuration = params[CONFIGURATION_PARAM]
-            )
-        }
+  override fun toSearchParams(): Map<String, String> = toParamsWithOnlyPageId(this)
+    .also { params ->
+      module?.let {
+        params[MODULE_PARAM] = module
+      }
+      configuration?.let {
+        params[CONFIGURATION_PARAM] = configuration
+      }
     }
+
+  companion object {
+
+    private const val MODULE_PARAM = "module"
+    private const val CONFIGURATION_PARAM = "configuration"
+
+    fun parser(params: Map<String, String?>): ModuleDependencyGraphNavRoute {
+      return ModuleDependencyGraphNavRoute(
+        module = params[MODULE_PARAM],
+        configuration = params[CONFIGURATION_PARAM]
+      )
+    }
+  }
 }
 
 
 object ModuleDependencyGraphReportPage : InvertReportPage<ModuleDependencyGraphNavRoute> {
-    override val navPage: NavPage = NavPage(
-        pageId = "module_dependency_graph",
-        displayName = "Module Dependency Graph",
-        navIconSlug = "diagram-3",
-        navRouteParser = { parser(it) }
-    )
+  override val navPage: NavPage = NavPage(
+    pageId = "module_dependency_graph",
+    displayName = "Module Dependency Graph",
+    navIconSlug = "diagram-3",
+    navRouteParser = { parser(it) }
+  )
 
-    override val navRouteKClass: KClass<ModuleDependencyGraphNavRoute> = ModuleDependencyGraphNavRoute::class
+  override val navRouteKClass: KClass<ModuleDependencyGraphNavRoute> = ModuleDependencyGraphNavRoute::class
 
-    override val composableContent: @Composable (ModuleDependencyGraphNavRoute) -> Unit = { navRoute ->
-        ModuleDependencyGraphComposable(navRoute)
-    }
+  override val composableContent: @Composable (ModuleDependencyGraphNavRoute) -> Unit = { navRoute ->
+    ModuleDependencyGraphComposable(navRoute)
+  }
 }
 
 
 @Serializable
 data class GraphNode(
-    val id: String,
-    val group: Int
+  val id: String,
+  val group: Int
 )
 
 @Serializable
 data class GraphLink(
-    val source: String,
-    val target: String,
-    val group: Int
+  val source: String,
+  val target: String,
+  val group: Int
 )
 
 @Serializable
 data class GraphData(
-    val nodes: MutableList<GraphNode> = mutableListOf(),
-    val links: MutableList<GraphLink> = mutableListOf(),
+  val nodes: MutableList<GraphNode> = mutableListOf(),
+  val links: MutableList<GraphLink> = mutableListOf(),
 )
 
 @Composable
 fun ModuleDependencyGraphComposable(
-    dependencyGraphNavRoute: ModuleDependencyGraphNavRoute,
-    reportDataRepo: ReportDataRepo = DependencyGraph.reportDataRepo,
-    navRouteRepo: NavRouteRepo = DependencyGraph.navRouteRepo,
+  dependencyGraphNavRoute: ModuleDependencyGraphNavRoute,
+  reportDataRepo: ReportDataRepo = DependencyGraph.reportDataRepo,
+  navRouteRepo: NavRouteRepo = DependencyGraph.navRouteRepo,
 ) {
-    val rootModulePath = dependencyGraphNavRoute.module ?: ":api:sales-report:impl"
-    val allDirectDeps by reportDataRepo.allDirectDependencies.collectAsState(null)
-    val allModules by reportDataRepo.allModules.collectAsState(null)
-    val allAnalyzedConfigurationNames by reportDataRepo.allAnalyzedConfigurationNames.collectAsState(null)
+  val rootModulePath = dependencyGraphNavRoute.module ?: ":api:sales-report:impl"
+  val allDirectDeps by reportDataRepo.allDirectDependencies.collectAsState(null)
+  val allModules by reportDataRepo.allModules.collectAsState(null)
+  val allAnalyzedConfigurationNames by reportDataRepo.allAnalyzedConfigurationNames.collectAsState(null)
 
-    if (allDirectDeps == null || allAnalyzedConfigurationNames == null) {
-        BootstrapLoadingMessageWithSpinner()
-        return
-    }
+  if (allDirectDeps == null || allAnalyzedConfigurationNames == null) {
+    BootstrapLoadingMessageWithSpinner()
+    return
+  }
 
-    val DEPENDENCY_GRAPH_MODULES_DATALIST_ID = "dependency_graph_modules_datalist"
-    Datalist({ id(DEPENDENCY_GRAPH_MODULES_DATALIST_ID) }) {
-        allModules?.map { Option(it) }
-    }
-    val ANALYZED_CONFIGURATION_NAMES_DATALIST_ID = "analyzed_configuration_names_datalist"
-    Datalist({ id(ANALYZED_CONFIGURATION_NAMES_DATALIST_ID) }) {
-        allAnalyzedConfigurationNames?.map { Option(it) }
-    }
+  val DEPENDENCY_GRAPH_MODULES_DATALIST_ID = "dependency_graph_modules_datalist"
+  Datalist({ id(DEPENDENCY_GRAPH_MODULES_DATALIST_ID) }) {
+    allModules?.map { Option(it) }
+  }
+  val ANALYZED_CONFIGURATION_NAMES_DATALIST_ID = "analyzed_configuration_names_datalist"
+  Datalist({ id(ANALYZED_CONFIGURATION_NAMES_DATALIST_ID) }) {
+    allAnalyzedConfigurationNames?.map { Option(it) }
+  }
 
-    val selectedConfiguration = dependencyGraphNavRoute.configuration ?: allAnalyzedConfigurationNames!!.first()
+  if (allAnalyzedConfigurationNames!!.isEmpty()) {
+    H1 { Text("No analyzed configurations found.") }
+    return
+  }
 
-    BootstrapRow {
-        BootstrapColumn(12) {
-            Fieldset {
-                Legend { Text("Module Dependency Graph") }
-                P {
-                    Label { Text("Module") }
-                    TextInput(dependencyGraphNavRoute.module ?: "") {
-                        classes("form-control")
-                        list(DEPENDENCY_GRAPH_MODULES_DATALIST_ID)
-                        placeholder("Module...")
-                        onInput { navRouteRepo.updateNavRoute(dependencyGraphNavRoute.copy(module = it.value)) }
-                    }
-                    TextInput(selectedConfiguration) {
-                        classes("form-control")
-                        list(ANALYZED_CONFIGURATION_NAMES_DATALIST_ID)
-                        placeholder("Configuration...")
-                        onInput { navRouteRepo.updateNavRoute(dependencyGraphNavRoute.copy(configuration = it.value)) }
-                    }
-                }
-            }
+  val selectedConfiguration = dependencyGraphNavRoute.configuration ?: allAnalyzedConfigurationNames!!.first()
+
+  BootstrapRow {
+    BootstrapColumn(12) {
+      Fieldset {
+        Legend { Text("Module Dependency Graph") }
+        P {
+          Label { Text("Module") }
+          TextInput(dependencyGraphNavRoute.module ?: "") {
+            classes("form-control")
+            list(DEPENDENCY_GRAPH_MODULES_DATALIST_ID)
+            placeholder("Module...")
+            onInput { navRouteRepo.updateNavRoute(dependencyGraphNavRoute.copy(module = it.value)) }
+          }
+          TextInput(selectedConfiguration) {
+            classes("form-control")
+            list(ANALYZED_CONFIGURATION_NAMES_DATALIST_ID)
+            placeholder("Configuration...")
+            onInput { navRouteRepo.updateNavRoute(dependencyGraphNavRoute.copy(configuration = it.value)) }
+          }
         }
+      }
+    }
+  }
+
+  val directDepsForModuleMap = allDirectDeps?.get(rootModulePath)
+
+
+  val graphDomId = "dependency-force-graph"
+  val width = 1200
+  val height = 768
+
+  fun pullModulesOnDebugRuntimeClasspathDeps(direct: Map<ConfigurationName, Set<DependencyId>>?): List<DependencyId> {
+    return direct
+      ?.filterKeys { it == selectedConfiguration }
+      ?.values
+      ?.flatten()
+      ?.filter { it.startsWith(":") }
+      ?: listOf()
+  }
+
+  val directDepsForModuleListFiltered = pullModulesOnDebugRuntimeClasspathDeps(directDepsForModuleMap)
+
+  println(dependencyGraphNavRoute.module)
+  println(allModules)
+  val isValidModule = allModules?.contains(dependencyGraphNavRoute.module) ?: false
+  if (isValidModule) {
+
+    if (directDepsForModuleListFiltered.isEmpty()) {
+      H1 { Text("${dependencyGraphNavRoute.module} has 0 direct dependencies on the $selectedConfiguration") }
+      return
     }
 
-    val directDepsForModuleMap = allDirectDeps?.get(rootModulePath)
-
-
-    val graphDomId = "dependency-force-graph"
-    val width = 1200
-    val height = 768
-
-    fun pullModulesOnDebugRuntimeClasspathDeps(direct: Map<ConfigurationName, Set<DependencyId>>?): List<DependencyId> {
-        return direct
-            ?.filterKeys { it == selectedConfiguration }
-            ?.values
-            ?.flatten()
-            ?.filter { it.startsWith(":") }
-            ?: listOf()
-    }
-
-    val directDepsForModuleListFiltered = pullModulesOnDebugRuntimeClasspathDeps(directDepsForModuleMap)
-
-    println(dependencyGraphNavRoute.module)
-    println(allModules)
-    val isValidModule = allModules?.contains(dependencyGraphNavRoute.module) ?: false
-    if (isValidModule) {
-
-        if (directDepsForModuleListFiltered.isEmpty()) {
-            H1 { Text("${dependencyGraphNavRoute.module} has 0 direct dependencies on the $selectedConfiguration") }
-            return
+    // Good to go
+    Div({
+      id(graphDomId)
+      style {
+        border {
+          width(2.px)
+          style(LineStyle.Solid)
+          color = Color.black
         }
-
-        // Good to go
-        Div({
-            id(graphDomId)
-            style {
-                border {
-                    width(2.px)
-                    style(LineStyle.Solid)
-                    color = Color.black
-                }
-                width(width.px)
-                height(height.px)
-            }
-        })
-    } else {
-        H1 { Text("Enter a valid module.") }
-        return
-    }
-
-    // https://github.com/vasturiano/force-graph
-    val forceGraphJsonData = GraphData()
-
-    fun findIdx(dependencyId: DependencyId): Int {
-        val idx = forceGraphJsonData.nodes.indexOfFirst { dependencyId == it.id }
-        return if (idx == -1) {
-            Random.nextInt()
-        } else {
-            idx
-        }
-    }
-
-    val maxDepth = 5
-
-    fun addMoreNodes(currDepth: Int, graphData: GraphData, modulePath: String, parentModulePath: String, groupId: Int) {
-        pullModulesOnDebugRuntimeClasspathDeps(allDirectDeps?.get(modulePath)).forEachIndexed { idx, depId ->
-            if (graphData.nodes.firstOrNull { it.id == depId } == null) {
-                graphData.nodes.add(GraphNode(depId, findIdx(depId)))
-                if (currDepth < maxDepth) {
-                    addMoreNodes(currDepth + 1, graphData, depId, modulePath, idx)
-                }
-            }
-            val newLink = GraphLink(depId, parentModulePath, groupId)
-            if (!graphData.links.contains(newLink)) {
-                graphData.links.add(newLink)
-            }
-        }
-    }
-
-    forceGraphJsonData.nodes.add(GraphNode(rootModulePath, findIdx(rootModulePath)))
-
-    directDepsForModuleListFiltered.forEach { dependencyId ->
-        forceGraphJsonData.nodes.add(GraphNode(dependencyId, findIdx(dependencyId)))
-    }
-
-    directDepsForModuleListFiltered.forEach {
-        addMoreNodes(1, forceGraphJsonData, it, rootModulePath, findIdx(rootModulePath))
-    }
-
-    forceGraphJsonData.links.addAll(directDepsForModuleListFiltered.map {
-        GraphLink(it, rootModulePath, findIdx(rootModulePath))
+        width(width.px)
+        height(height.px)
+      }
     })
+  } else {
+    H1 { Text("Enter a valid module.") }
+    return
+  }
 
-    CoroutineScope(Dispatchers.Main).launch {
-        delay(200)
-        render3dGraph(
-            graphDomId,
-            InvertSerialization.InvertJson.encodeToString(GraphData.serializer(), forceGraphJsonData),
-            width,
-            height
-        )
+  // https://github.com/vasturiano/force-graph
+  val forceGraphJsonData = GraphData()
+
+  fun findIdx(dependencyId: DependencyId): Int {
+    val idx = forceGraphJsonData.nodes.indexOfFirst { dependencyId == it.id }
+    return if (idx == -1) {
+      Random.nextInt()
+    } else {
+      idx
     }
+  }
+
+  val maxDepth = 5
+
+  fun addMoreNodes(currDepth: Int, graphData: GraphData, modulePath: String, parentModulePath: String, groupId: Int) {
+    pullModulesOnDebugRuntimeClasspathDeps(allDirectDeps?.get(modulePath)).forEachIndexed { idx, depId ->
+      if (graphData.nodes.firstOrNull { it.id == depId } == null) {
+        graphData.nodes.add(GraphNode(depId, findIdx(depId)))
+        if (currDepth < maxDepth) {
+          addMoreNodes(currDepth + 1, graphData, depId, modulePath, idx)
+        }
+      }
+      val newLink = GraphLink(depId, parentModulePath, groupId)
+      if (!graphData.links.contains(newLink)) {
+        graphData.links.add(newLink)
+      }
+    }
+  }
+
+  forceGraphJsonData.nodes.add(GraphNode(rootModulePath, findIdx(rootModulePath)))
+
+  directDepsForModuleListFiltered.forEach { dependencyId ->
+    forceGraphJsonData.nodes.add(GraphNode(dependencyId, findIdx(dependencyId)))
+  }
+
+  directDepsForModuleListFiltered.forEach {
+    addMoreNodes(1, forceGraphJsonData, it, rootModulePath, findIdx(rootModulePath))
+  }
+
+  forceGraphJsonData.links.addAll(directDepsForModuleListFiltered.map {
+    GraphLink(it, rootModulePath, findIdx(rootModulePath))
+  })
+
+  CoroutineScope(Dispatchers.Main).launch {
+    delay(200)
+    render3dGraph(
+      graphDomId,
+      InvertSerialization.InvertJson.encodeToString(GraphData.serializer(), forceGraphJsonData),
+      width,
+      height
+    )
+  }
 }
 

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/ModuleDependencyGraphReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/ModuleDependencyGraphReportPage.kt
@@ -152,13 +152,13 @@ fun ModuleDependencyGraphComposable(
             classes("form-control")
             list(DEPENDENCY_GRAPH_MODULES_DATALIST_ID)
             placeholder("Module...")
-            onInput { navRouteRepo.updateNavRoute(dependencyGraphNavRoute.copy(module = it.value)) }
+            onInput { navRouteRepo.pushNavRoute(dependencyGraphNavRoute.copy(module = it.value)) }
           }
           TextInput(selectedConfiguration) {
             classes("form-control")
             list(ANALYZED_CONFIGURATION_NAMES_DATALIST_ID)
             placeholder("Configuration...")
-            onInput { navRouteRepo.updateNavRoute(dependencyGraphNavRoute.copy(configuration = it.value)) }
+            onInput { navRouteRepo.pushNavRoute(dependencyGraphNavRoute.copy(configuration = it.value)) }
           }
         }
       }

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/ModuleDetailReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/ModuleDetailReportPage.kt
@@ -110,7 +110,7 @@ fun ModuleDetailComposable(
       Text("Module $modulePath is owned by ")
       AppLink({
         onClick {
-          navRouteRepo.updateNavRoute(OwnerDetailNavRoute(ownerName))
+          navRouteRepo.pushNavRoute(OwnerDetailNavRoute(ownerName))
         }
       }) {
         Text(ownerName)
@@ -146,7 +146,7 @@ fun ModuleDetailComposable(
           types = listOf(String::class, Int::class),
           maxResultsLimitConstant = MAX_RESULTS,
           onItemClickCallback = {
-            navRouteRepo.updateNavRoute(
+            navRouteRepo.pushNavRoute(
               StatDetailNavRoute(
                 statKeys = listOf(statInfos!!.first { statInfo -> statInfo.description == it[0] }).map { it.key }
               )
@@ -195,7 +195,7 @@ fun ModuleDetailComposable(
         types = listOf(String::class, String::class),
         maxResultsLimitConstant = MAX_RESULTS,
         onItemClickCallback = {
-          navRouteRepo.updateNavRoute(ModuleDetailNavRoute(it[0]))
+          navRouteRepo.pushNavRoute(ModuleDetailNavRoute(it[0]))
         }
       )
     }
@@ -210,7 +210,7 @@ fun ModuleDetailComposable(
         types = moduleUsage.keys.map { String::class },
         maxResultsLimitConstant = MAX_RESULTS,
         onItemClickCallback = {
-          navRouteRepo.updateNavRoute(
+          navRouteRepo.pushNavRoute(
             ModuleDetailNavRoute(
               it[0]
             )
@@ -259,7 +259,7 @@ fun ModuleDetailComposable(
         types = listOf(String::class, String::class),
         maxResultsLimitConstant = MAX_RESULTS,
         onItemClickCallback = {
-          navRouteRepo.updateNavRoute(ModuleDetailNavRoute(it[0]))
+          navRouteRepo.pushNavRoute(ModuleDetailNavRoute(it[0]))
         }
       )
     })
@@ -275,7 +275,7 @@ fun ModuleDetailComposable(
         types = moduleUsage.keys.map { String::class },
         maxResultsLimitConstant = MAX_RESULTS,
         onItemClickCallback = {
-          navRouteRepo.updateNavRoute(
+          navRouteRepo.pushNavRoute(
             ModuleDetailNavRoute(
               it[0]
             )
@@ -288,7 +288,7 @@ fun ModuleDetailComposable(
   pluginsForModule?.let {pluginsForModuleNonNull ->
     pageTabs.add(BootstrapTabData(tabName = "Gradle Plugins") {
       BootstrapClickableList("Gradle Plugins", pluginsForModuleNonNull, MAX_RESULTS) {
-        navRouteRepo.updateNavRoute(
+        navRouteRepo.pushNavRoute(
           PluginDetailNavRoute(
             pluginId = it
           )

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/OwnerBreakdownReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/OwnerBreakdownReportPage.kt
@@ -188,7 +188,7 @@ fun ByOwnerComposable(
               owner = null,
               statKey = null,
             ),
-            navRouteRepo::updateNavRoute
+            navRouteRepo::pushNavRoute
           ) {
             Text("View All")
           }
@@ -207,7 +207,7 @@ fun ByOwnerComposable(
             currentValue = ownerParamValue,
             options = allOwnerNames!!.map { BootstrapSelectOption(it, it) }
           ) {
-            navRouteRepo.updateNavRoute(
+            navRouteRepo.pushNavRoute(
               navRoute.copy(
                 owner = it?.value
               )
@@ -229,7 +229,7 @@ fun ByOwnerComposable(
             )
           }
         ) {
-          navRouteRepo.updateNavRoute(
+          navRouteRepo.pushNavRoute(
             navRoute.copy(
               statKey = it?.value
             )
@@ -263,7 +263,7 @@ fun ByOwnerComposable(
           Li {
             NavRouteLink(
               navRoute.copy(statKey = statMetadata.key),
-              navRouteRepo::updateNavRoute
+              navRouteRepo::pushNavRoute
             ) {
               Text(statMetadata.description + " (" + statMetadata.key + ")")
             }
@@ -328,7 +328,7 @@ fun ByOwnerComposable(
                   )
                 ),
                 onClick = { label, value ->
-                  navRouteRepo.updateNavRoute(
+                  navRouteRepo.pushNavRoute(
                     CodeReferencesNavRoute(
                       statKey = statKey,
                       owner = label,
@@ -355,7 +355,7 @@ fun ByOwnerComposable(
                   )
                 ),
                 onClick = { label, value ->
-                  navRouteRepo.updateNavRoute(
+                  navRouteRepo.pushNavRoute(
                     CodeReferencesNavRoute(
                       statKey = statKey,
                       owner = label,
@@ -403,7 +403,7 @@ fun ByOwnerComposable(
               "Code References in Modules",
             ),
             onItemClickCallback = {
-              navRouteRepo.updateNavRoute(
+              navRouteRepo.pushNavRoute(
                 CodeReferencesNavRoute(
                   statKey = statKey,
                   owner = it[0]

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/OwnerBreakdownReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/OwnerBreakdownReportPage.kt
@@ -41,6 +41,7 @@ import ui.BootstrapSelectOption
 import ui.BootstrapTabData
 import ui.BootstrapTabPane
 import ui.BootstrapTable
+import ui.NavRouteLink
 import kotlin.reflect.KClass
 
 data class OwnerBreakdownNavRoute(
@@ -182,16 +183,15 @@ fun ByOwnerComposable(
         Text("Owner Breakdown")
         if (!navRoute.statKey.isNullOrBlank()) {
           Text(" (")
-          A(href = "#", {
-            onClick {
-              navRouteRepo.updateNavRoute(
-                navRoute.copy(
-                  owner = null,
-                  statKey = null,
-                )
-              )
-            }
-          }) { Text("View All") }
+          NavRouteLink(
+            navRoute.copy(
+              owner = null,
+              statKey = null,
+            ),
+            navRouteRepo::updateNavRoute
+          ) {
+            Text("View All")
+          }
           Text(")")
         }
       }
@@ -261,11 +261,10 @@ fun ByOwnerComposable(
       Ul {
         codeReferenceStatTypes.forEach { statMetadata ->
           Li {
-            A("#", {
-              onClick {
-                navRouteRepo.updateNavRoute(navRoute.copy(statKey = statMetadata.key))
-              }
-            }) {
+            NavRouteLink(
+              navRoute.copy(statKey = statMetadata.key),
+              navRouteRepo::updateNavRoute
+            ) {
               Text(statMetadata.description + " (" + statMetadata.key + ")")
             }
           }

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/OwnerDetailReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/OwnerDetailReportPage.kt
@@ -79,7 +79,7 @@ fun OwnerDetailComposable(
             types = listOf(String::class),
             maxResultsLimitConstant = MAX_RESULTS
         ) { cellValues ->
-            navRouteRepo.updateNavRoute(ModuleDetailNavRoute(cellValues[0]))
+            navRouteRepo.pushNavRoute(ModuleDetailNavRoute(cellValues[0]))
         }
     }
 

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/OwnersReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/OwnersReportPage.kt
@@ -35,7 +35,6 @@ object OwnersReportPage : InvertReportPage<OwnersNavRoute> {
     override val composableContent: @Composable (OwnersNavRoute) -> Unit = { navRoute ->
         OwnersComposable(navRoute)
     }
-
 }
 
 
@@ -68,7 +67,7 @@ fun OwnersComposable(
             )
         ),
         onClick = { label, value ->
-            navRouteRepo.updateNavRoute(
+            navRouteRepo.pushNavRoute(
                 OwnerDetailNavRoute(
                     owner = label,
                 )
@@ -88,6 +87,6 @@ fun OwnersComposable(
         maxResultsLimitConstant = PagingConstants.MAX_RESULTS
     ) { cellValues ->
         val owner = cellValues[0]
-        navRouteRepo.updateNavRoute(OwnerDetailNavRoute(owner))
+        navRouteRepo.pushNavRoute(OwnerDetailNavRoute(owner))
     }
 }

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/PluginDetailReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/PluginDetailReportPage.kt
@@ -68,7 +68,7 @@ fun PluginDetailComposable(
         TitleRow("Plugin Detail ${navRoute.pluginId} is used by ${modules.size} Modules:")
         Br()
         BootstrapClickableList("Modules Using ${pluginId}", modules, PagingConstants.MAX_RESULTS) { gradlePath ->
-            navRouteRepo.updateNavRoute(ModuleDetailNavRoute(gradlePath))
+            navRouteRepo.pushNavRoute(ModuleDetailNavRoute(gradlePath))
         }
     }
 

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/StatDetailReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/StatDetailReportPage.kt
@@ -160,7 +160,7 @@ fun StatDetailComposable(
     query = query ?: "",
     placeholderText = "Module Filter...",
   ) {
-    navRouteRepo.updateNavRoute(statsNavRoute.copy(moduleQuery = it))
+    navRouteRepo.pushNavRoute(statsNavRoute.copy(moduleQuery = it))
   }
 
   val SUPPORTED_TYPES = listOf(
@@ -269,7 +269,7 @@ fun StatDetailComposable(
           types = headers.map { MarkdownCellContent::class },
           maxResultsLimitConstant = PagingConstants.MAX_RESULTS
         ) { cellValues ->
-          navRouteRepo.updateNavRoute(ModuleDetailNavRoute(cellValues[0]))
+          navRouteRepo.pushNavRoute(ModuleDetailNavRoute(cellValues[0]))
         }
       } else {
         H3 { Text("No Collected Stats of Type(s) ${statsNavRoute.statKeys}") }

--- a/invert-report/src/jsMain/kotlin/history/JavaScriptNavigationAndHistory.kt
+++ b/invert-report/src/jsMain/kotlin/history/JavaScriptNavigationAndHistory.kt
@@ -56,11 +56,14 @@ class JavaScriptNavigationAndHistory(
         val jsonState = InvertJson.encodeToString(HistoryState.serializer(), HistoryState(navRoute.toSearchParams()))
         val isNewPage =
           currUrlParamsMap[BaseNavRoute.PAGE_ID_PARAM] != newNavRouteParamsMap[BaseNavRoute.PAGE_ID_PARAM]
-        if (isNewPage) {
-          window.history.pushState(jsonState, "", newUrl.toString())
-        } else {
-          window.history.replaceState(jsonState, "", newUrl.toString())
-        }
+        val newUrlStr = newUrl.toString()
+//        if (isNewPage) {
+          println("pushState $newUrlStr")
+          window.history.pushState(jsonState, "", newUrlStr)
+//        } else {
+//          println("replaceState $newUrlStr")
+//          window.history.replaceState(jsonState, "", newUrlStr)
+//        }
       }
     }
   }
@@ -74,7 +77,7 @@ class JavaScriptNavigationAndHistory(
           try {
             val navRouteParams =
               InvertJson.decodeFromString(HistoryState.serializer(), it.state.toString()).params
-            val newRoute = routeManager.parseParamsToRoute(navRouteParams)
+            val newRoute: NavRoute = routeManager.parseParamsToRoute(navRouteParams)
             MainScope().launch {
               if (navRouteRepo.navRoute.first() != newRoute) {
                 navRouteRepo.updateNavRoute(newRoute)

--- a/invert-report/src/jsMain/kotlin/history/JavaScriptNavigationAndHistory.kt
+++ b/invert-report/src/jsMain/kotlin/history/JavaScriptNavigationAndHistory.kt
@@ -15,6 +15,7 @@ import org.w3c.dom.PopStateEvent
 import org.w3c.dom.url.URL
 import org.w3c.dom.url.URLSearchParams
 
+
 class JavaScriptNavigationAndHistory(
   private val routeManager: NavRouteManager,
   private val navRouteRepo: NavRouteRepo
@@ -27,7 +28,7 @@ class JavaScriptNavigationAndHistory(
       return map
     }
 
-    fun setUrlFromNavRoute(navRoute: NavRoute) {
+    fun setUrlFromNavRoute(navRoute: NavRoute, pushOrReplaceState: PushOrReplaceState) {
       val newUrl = URL(window.location.toString())
 
       val currUrlParamsMap = mutableMapOf<String, String>().also { urlParamsMap ->
@@ -57,13 +58,16 @@ class JavaScriptNavigationAndHistory(
         val isNewPage =
           currUrlParamsMap[BaseNavRoute.PAGE_ID_PARAM] != newNavRouteParamsMap[BaseNavRoute.PAGE_ID_PARAM]
         val newUrlStr = newUrl.toString()
-//        if (isNewPage) {
-          println("pushState $newUrlStr")
-          window.history.pushState(jsonState, "", newUrlStr)
-//        } else {
-//          println("replaceState $newUrlStr")
-//          window.history.replaceState(jsonState, "", newUrlStr)
-//        }
+        Log.d("$pushOrReplaceState $newUrlStr")
+        when (pushOrReplaceState) {
+          PushOrReplaceState.PUSH -> {
+            window.history.pushState(jsonState, "", newUrlStr)
+          }
+
+          PushOrReplaceState.REPLACE -> {
+            window.history.replaceState(jsonState, "", newUrlStr)
+          }
+        }
       }
     }
   }

--- a/invert-report/src/jsMain/kotlin/history/JavaScriptNavigationAndHistory.kt
+++ b/invert-report/src/jsMain/kotlin/history/JavaScriptNavigationAndHistory.kt
@@ -84,7 +84,7 @@ class JavaScriptNavigationAndHistory(
             val newRoute: NavRoute = routeManager.parseParamsToRoute(navRouteParams)
             MainScope().launch {
               if (navRouteRepo.navRoute.first() != newRoute) {
-                navRouteRepo.updateNavRoute(newRoute)
+                navRouteRepo.pushNavRoute(newRoute)
               }
             }
           } catch (e: Throwable) {

--- a/invert-report/src/jsMain/kotlin/history/PushOrReplaceState.kt
+++ b/invert-report/src/jsMain/kotlin/history/PushOrReplaceState.kt
@@ -1,0 +1,6 @@
+package history
+
+enum class PushOrReplaceState {
+  PUSH,
+  REPLACE
+}

--- a/invert-report/src/jsMain/kotlin/navigation/NavigationComposables.kt
+++ b/invert-report/src/jsMain/kotlin/navigation/NavigationComposables.kt
@@ -23,6 +23,7 @@ import com.squareup.invert.common.pages.GradleRepositoriesReportPage
 import com.squareup.invert.common.pages.KotlinCompilerPluginsReportPage
 import com.squareup.invert.common.pages.PluginDetailNavRoute
 import com.squareup.invert.common.utils.FormattingUtils.dateDisplayStr
+import history.PushOrReplaceState
 import org.jetbrains.compose.web.attributes.ATarget.Blank
 import org.jetbrains.compose.web.attributes.target
 import org.jetbrains.compose.web.dom.A
@@ -45,7 +46,10 @@ fun LeftNavigationComposable(
   navGroupsRepo: NavGroupsRepo,
 ) {
   val currentNavRoute by navRouteRepo.navRoute.collectAsState(
-    NavRouteRepo.NavChangeEvent(initialRoute)
+    NavRouteRepo.NavChangeEvent(
+      initialRoute,
+      PushOrReplaceState.PUSH
+    )
   )
   val metadataOrig by reportDataRepo.reportMetadata.collectAsState(null)
 
@@ -118,7 +122,7 @@ fun LeftNavigationComposable(
                           })
                       onClick {
                         it.preventDefault()
-                        navRouteRepo.updateNavRoute(rootNavItem.destinationNavRoute)
+                        navRouteRepo.pushNavRoute(rootNavItem.destinationNavRoute)
                       }
                     }) {
 

--- a/invert-report/src/jsMain/kotlin/navigation/NavigationComposables.kt
+++ b/invert-report/src/jsMain/kotlin/navigation/NavigationComposables.kt
@@ -9,6 +9,7 @@ import com.squareup.invert.common.navigation.NavPage
 import com.squareup.invert.common.navigation.NavPageGroup
 import com.squareup.invert.common.navigation.NavRoute
 import com.squareup.invert.common.navigation.NavRouteRepo
+import com.squareup.invert.common.navigation.routes.toQueryString
 import com.squareup.invert.common.navigation.toNavItem
 import com.squareup.invert.common.pages.AnnotationProcessorsReportPage
 import com.squareup.invert.common.pages.ArtifactDetailNavRoute
@@ -102,7 +103,7 @@ fun LeftNavigationComposable(
                 val activeTab = rootNavItem.matchesCurrentNavRoute(currentNavRoute)
                 Li {
                   A(
-                    href = "#",
+                    href = rootNavItem.destinationNavRoute.toQueryString(),
                     {
                       classes(
                         "nav-link link-body-emphasis d-inline-flex text-decoration-none rounded".split(
@@ -113,7 +114,10 @@ fun LeftNavigationComposable(
                               it.add("active")
                             }
                           })
-                      onClick { navRouteRepo.updateNavRoute(rootNavItem.destinationNavRoute) }
+                      onClick {
+                        it.preventDefault()
+                        navRouteRepo.updateNavRoute(rootNavItem.destinationNavRoute)
+                      }
                     }) {
 
                     BootstrapIcon(rootNavItem.navIconSlug) {}

--- a/invert-report/src/jsMain/kotlin/navigation/NavigationComposables.kt
+++ b/invert-report/src/jsMain/kotlin/navigation/NavigationComposables.kt
@@ -44,7 +44,9 @@ fun LeftNavigationComposable(
   reportDataRepo: ReportDataRepo,
   navGroupsRepo: NavGroupsRepo,
 ) {
-  val currentNavRoute by navRouteRepo.navRoute.collectAsState(initialRoute)
+  val currentNavRoute by navRouteRepo.navRoute.collectAsState(
+    NavRouteRepo.NavChangeEvent(initialRoute)
+  )
   val metadataOrig by reportDataRepo.reportMetadata.collectAsState(null)
 
   Ul({ classes("list-unstyled", "ps-0") }) {
@@ -100,7 +102,7 @@ fun LeftNavigationComposable(
           }) {
             Ul({ classes("btn-toggle-nav list-unstyled fw-normal pb-1 small".split(" ")) }) {
               navPageGroup.navItems.forEach { rootNavItem: NavPage.NavItem ->
-                val activeTab = rootNavItem.matchesCurrentNavRoute(currentNavRoute)
+                val activeTab = rootNavItem.matchesCurrentNavRoute(currentNavRoute.navRoute)
                 Li {
                   A(
                     href = rootNavItem.destinationNavRoute.toQueryString(),

--- a/invert-report/src/jsMain/kotlin/ui/BootstrapComposables.kt
+++ b/invert-report/src/jsMain/kotlin/ui/BootstrapComposables.kt
@@ -325,27 +325,6 @@ fun GenericList(
   )
 }
 
-
-@Composable
-fun BootstrapNavSectionHeader(title: String, iconSlug: String? = null) {
-  H6({
-    classes(
-      "sidebar-heading d-flex justify-content-between px-3 mt-4 mb-1 text-muted"
-        .split(" ")
-    )
-  }) {
-    Text(title.uppercase())
-    iconSlug?.let {
-      A("#", {
-        classes("d-flex text-muted".split(" "))
-      }) {
-        BootstrapIcon(iconSlug) {}
-      }
-    }
-  }
-}
-
-
 @Composable
 fun BootstrapJumbotron(
   centered: Boolean = false,

--- a/invert-report/src/jsMain/kotlin/ui/NavRouteLink.kt
+++ b/invert-report/src/jsMain/kotlin/ui/NavRouteLink.kt
@@ -1,0 +1,24 @@
+package ui
+
+import androidx.compose.runtime.Composable
+import com.squareup.invert.common.navigation.NavRoute
+import com.squareup.invert.common.navigation.routes.toQueryString
+import org.jetbrains.compose.web.dom.A
+
+@Composable
+fun NavRouteLink(
+  navRoute: NavRoute,
+  updateNavRoute: (NavRoute) -> Unit,
+  content: @Composable () -> Unit,
+) {
+  A(
+    navRoute.toQueryString(),
+    {
+      onClick {
+        it.preventDefault()
+        updateNavRoute(navRoute)
+      }
+    }) {
+    content()
+  }
+}

--- a/invert-report/src/jsMain/kotlin/ui/NavRouteLink.kt
+++ b/invert-report/src/jsMain/kotlin/ui/NavRouteLink.kt
@@ -5,6 +5,9 @@ import com.squareup.invert.common.navigation.NavRoute
 import com.squareup.invert.common.navigation.routes.toQueryString
 import org.jetbrains.compose.web.dom.A
 
+/**
+ * Creates an "a" element link for a [NavRoute].
+ */
 @Composable
 fun NavRouteLink(
   navRoute: NavRoute,
@@ -18,7 +21,8 @@ fun NavRouteLink(
         it.preventDefault()
         updateNavRoute(navRoute)
       }
-    }) {
+    }
+  ) {
     content()
   }
 }


### PR DESCRIPTION
Fixing navigation to stop adding on random "#" to the URL and avoid page reloads!  Note: This breaks what we have for search queries, but we can come back and make that the alternate way.