### PR TITLE
StatMetadata "description" -> "title" and new "description" field.

### DIFF
--- a/invert-collectors/src/main/kotlin/com/squareup/invert/collectors/contains/InvertContainsStatCollector.kt
+++ b/invert-collectors/src/main/kotlin/com/squareup/invert/collectors/contains/InvertContainsStatCollector.kt
@@ -46,7 +46,7 @@ open class InvertContainsStatCollector(
         CollectedStat(
           metadata = StatMetadata(
             key = statKey,
-            description = statDescription,
+            title = statDescription,
             dataType = StatDataType.CODE_REFERENCES,
           ),
           stat = Stat.CodeReferencesStat(codeReferences)

--- a/invert-collectors/src/main/kotlin/com/squareup/invert/collectors/linesofcode/LinesOfCodeStatCollector.kt
+++ b/invert-collectors/src/main/kotlin/com/squareup/invert/collectors/linesofcode/LinesOfCodeStatCollector.kt
@@ -24,14 +24,14 @@ open class LinesOfCodeStatCollector(
 
   private val fileCountStatMetadata: StatMetadata = StatMetadata(
     key = "file_count_$keySuffix",
-    description = "File Count - $name",
+    title = "File Count - $name",
     dataType = StatDataType.NUMERIC,
     category = STAT_CATEGORY_LINES_OF_CODE,
   )
 
   private val linesOfCodeStatMetadata: StatMetadata = StatMetadata(
     key = "lines_of_code_$keySuffix",
-    description = "Lines of Code - $name",
+    title = "Lines of Code - $name",
     dataType = StatDataType.NUMERIC,
     category = STAT_CATEGORY_LINES_OF_CODE,
   )

--- a/invert-gradle-plugin/src/test/kotlin/com/squareup/invert/internal/report/js/InvertJsReportUtilsTest.kt
+++ b/invert-gradle-plugin/src/test/kotlin/com/squareup/invert/internal/report/js/InvertJsReportUtilsTest.kt
@@ -27,13 +27,13 @@ class InvertJsReportUtilsTest {
 
     val codeRefStatInfo = StatMetadata(
       key = "code_reference_stat",
-      description = "Code Reference Stat",
+      title = "Code Reference Stat",
       dataType = StatDataType.CODE_REFERENCES,
     )
 
     val numericStatInfo = StatMetadata(
       key = "numeric_stat",
-      description = "Numeric Stat",
+      title = "Numeric Stat",
       dataType = StatDataType.NUMERIC,
     )
 

--- a/invert-gradle-plugin/src/test/kotlin/com/squareup/invert/internal/report/js/InvertJsReportUtilsTest.kt
+++ b/invert-gradle-plugin/src/test/kotlin/com/squareup/invert/internal/report/js/InvertJsReportUtilsTest.kt
@@ -89,7 +89,7 @@ class InvertJsReportUtilsTest {
     "code_reference_stat": {
         "metadata": {
             "key": "code_reference_stat",
-            "description": "Code Reference Stat",
+            "title": "Code Reference Stat",
             "dataType": "CODE_REFERENCES"
         },
         "total": 6,
@@ -101,7 +101,7 @@ class InvertJsReportUtilsTest {
     "numeric_stat": {
         "metadata": {
             "key": "numeric_stat",
-            "description": "Numeric Stat",
+            "title": "Numeric Stat",
             "dataType": "NUMERIC"
         },
         "total": 62,

--- a/invert-models/src/commonMain/kotlin/com/squareup/invert/models/Stat.kt
+++ b/invert-models/src/commonMain/kotlin/com/squareup/invert/models/Stat.kt
@@ -43,7 +43,7 @@ sealed interface Stat {
       val startLine: Int,
       val endLine: Int,
       val extras: Map<ExtraKey, String> = emptyMap(),
-      val code: String? = null,
+      val code: Markdown? = null,
       val owner: OwnerName? = null,
     )
   }

--- a/invert-models/src/commonMain/kotlin/com/squareup/invert/models/StatMetadata.kt
+++ b/invert-models/src/commonMain/kotlin/com/squareup/invert/models/StatMetadata.kt
@@ -9,7 +9,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class StatMetadata(
   val key: StatKey,
-  val description: String,
+  val title: String,
   val dataType: StatDataType,
   val category: String = "Stats",
   val extras: List<ExtraMetadata> = emptyList(),

--- a/invert-models/src/commonMain/kotlin/com/squareup/invert/models/StatMetadata.kt
+++ b/invert-models/src/commonMain/kotlin/com/squareup/invert/models/StatMetadata.kt
@@ -10,6 +10,10 @@ import kotlinx.serialization.Serializable
 data class StatMetadata(
   val key: StatKey,
   val title: String,
+  /**
+   * Use this field to give context on what this [Stat] is and why it's important.
+   */
+  val description: Markdown? = null,
   val dataType: StatDataType,
   val category: String = "Stats",
   val extras: List<ExtraMetadata> = emptyList(),

--- a/invert-models/src/commonMain/kotlin/com/squareup/invert/models/StatMetadata.kt
+++ b/invert-models/src/commonMain/kotlin/com/squareup/invert/models/StatMetadata.kt
@@ -13,8 +13,8 @@ data class StatMetadata(
   /**
    * Use this field to give context on what this [Stat] is and why it's important.
    */
-  val description: Markdown? = null,
   val dataType: StatDataType,
+  val description: Markdown? = null,
   val category: String = "Stats",
   val extras: List<ExtraMetadata> = emptyList(),
 )

--- a/invert-models/src/commonMain/kotlin/com/squareup/invert/models/Typealiases.kt
+++ b/invert-models/src/commonMain/kotlin/com/squareup/invert/models/Typealiases.kt
@@ -3,6 +3,7 @@ package com.squareup.invert.models
 typealias DependencyId = String
 typealias ConfigurationName = String
 typealias GradlePluginId = String
+typealias Markdown = String
 typealias ModulePath = String
 typealias FileKey = String
 typealias OwnerName = String

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/AllStatsReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/AllStatsReportPage.kt
@@ -20,8 +20,6 @@ import com.squareup.invert.models.StatMetadata
 import com.squareup.invert.models.js.StatTotalAndMetadata
 import org.jetbrains.compose.web.dom.H1
 import org.jetbrains.compose.web.dom.Text
-import ui.BootstrapButton
-import ui.BootstrapButtonType
 import ui.BootstrapColumn
 import ui.BootstrapJumbotron
 import ui.BootstrapLoadingMessageWithSpinner
@@ -117,7 +115,7 @@ fun AllStatsComposable(
       .map { statMetadata: StatMetadata ->
         mutableListOf<String>(
           statMetadata.key,
-          statMetadata.description,
+          statMetadata.title,
           statMetadata.dataType.name,
           statMetadata.category
         ).apply {
@@ -147,7 +145,7 @@ fun AllStatsComposable(
 @Composable
 fun StatTiles(codeReferenceStatTotals: List<StatTotalAndMetadata>, onClick: (NavRoute) -> Unit) {
   BootstrapRow {
-    codeReferenceStatTotals.sortedBy { it.metadata.description }.forEach { statTotalAndMetadata ->
+    codeReferenceStatTotals.sortedBy { it.metadata.title }.forEach { statTotalAndMetadata ->
       val statMetadata = statTotalAndMetadata.metadata
       BootstrapColumn(4) {
         BootstrapJumbotron(
@@ -169,7 +167,7 @@ fun StatTiles(codeReferenceStatTotals: List<StatTotalAndMetadata>, onClick: (Nav
             },
             onClick,
           ) {
-            Text(statTotalAndMetadata.metadata.description)
+            Text(statTotalAndMetadata.metadata.title)
           }
         }
       }

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/CodeReferencesReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/CodeReferencesReportPage.kt
@@ -172,7 +172,7 @@ fun CodeReferencesComposable(
       H4 {
         Text(buildString {
           append("Code References")
-          append(" for ${currentStatMetadata.description} (${codeReferencesNavRoute.statKey})")
+          append(" for ${currentStatMetadata.title} (${codeReferencesNavRoute.statKey})")
         })
       }
     }
@@ -317,7 +317,7 @@ fun CodeReferencesComposable(
           val remainingStat = currentHistoricalData.statTotalsAndMetadata.statTotals[remainingStatKey]!!.metadata
           datasets.add(
             ChartsJs.ChartJsDataset(
-              label = remainingStat.description,
+              label = remainingStat.title,
               data = values
             )
           )

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/HomeReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/HomeReportPage.kt
@@ -158,7 +158,7 @@ fun HomeComposable(
           }
           NavRouteLink(destRoute, navRouteRepo::pushNavRoute) {
             Small {
-              Text(statTotalAndMetadata.metadata.description)
+              Text(statTotalAndMetadata.metadata.title)
             }
           }
         }

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/ModuleDetailReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/ModuleDetailReportPage.kt
@@ -141,14 +141,14 @@ fun ModuleDetailComposable(
           headers = listOf("Stat", "Value"),
           rows = statsForModuleMap.filter { it.key != null && it.value is Stat.NumericStat }
             .map { (key, value) ->
-              listOf(key!!.description, (value as Stat.NumericStat).value.toString())
+              listOf(key!!.title, (value as Stat.NumericStat).value.toString())
             },
           types = listOf(String::class, Int::class),
           maxResultsLimitConstant = MAX_RESULTS,
           onItemClickCallback = {
             navRouteRepo.pushNavRoute(
               StatDetailNavRoute(
-                statKey = statInfos!!.first { statInfo -> statInfo.description == it[0] }.key
+                statKey = statInfos!!.first { statInfo -> statInfo.title == it[0] }.key
               )
             )
           },

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/OwnerBreakdownReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/OwnerBreakdownReportPage.kt
@@ -166,14 +166,14 @@ fun ByOwnerComposable(
   }
 
   fun getStatDescription(statKey: StatKey): String {
-    return statInfosOrig?.first { it.key == statKey }?.description ?: statKey
+    return statInfosOrig?.first { it.key == statKey }?.title ?: statKey
   }
 
   val ownerParamValue = navRoute.owner
 
   val codeReferenceStatTypes = statInfosOrig!!
     .filter { it.dataType == StatDataType.CODE_REFERENCES }
-    .sortedBy { it.description }
+    .sortedBy { it.title }
 
   BootstrapRow {
     BootstrapColumn(classes = listOf("text-center")) {
@@ -223,7 +223,7 @@ fun ByOwnerComposable(
           options = codeReferenceStatTypes.map {
             BootstrapSelectOption(
               value = it.key,
-              displayText = "${it.description} (${it.key})"
+              displayText = "${it.title} (${it.key})"
             )
           }
         ) {
@@ -263,7 +263,7 @@ fun ByOwnerComposable(
               navRoute.copy(statKey = statMetadata.key),
               navRouteRepo::pushNavRoute
             ) {
-              Text(statMetadata.description + " (" + statMetadata.key + ")")
+              Text(statMetadata.title + " (" + statMetadata.key + ")")
             }
           }
         }
@@ -326,7 +326,7 @@ fun ByOwnerComposable(
                   labels = bySize.keys,
                   datasets = listOf(
                     ChartsJs.ChartJsDataset(
-                      label = "References of ${statMetadata?.description}",
+                      label = "References of ${statMetadata?.title}",
                       data = bySize.values
                     )
                   )
@@ -353,7 +353,7 @@ fun ByOwnerComposable(
                   labels = bySize.keys,
                   datasets = listOf(
                     ChartsJs.ChartJsDataset(
-                      label = "References Count of ${statMetadata?.description}",
+                      label = "References Count of ${statMetadata?.title}",
                       data = bySize.values
                     )
                   )

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/StatDetailReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/StatDetailReportPage.kt
@@ -126,7 +126,7 @@ fun StatDetailComposable(
 
   H1 {
     Text(buildString {
-      append(statInfo.description)
+      append(statInfo.title)
     })
   }
 
@@ -202,7 +202,7 @@ fun StatDetailComposable(
           if (!moduleToOwnerMapFlowValue.isNullOrEmpty()) {
             add("Owner")
           }
-          val statDescription = statInfo.description
+          val statDescription = statInfo.title
           add(statDescription)
           add("$statDescription Details")
         }


### PR DESCRIPTION
We've found the need to provide more context for a given `Stat`.  It's a weird switch of field names from an upgrade standpoint, but we've been able to use refactoring to do it smoothly.