### PR TITLE
Added new (optional) markdown string "documentation" field for a Stat.

### DIFF
--- a/invert-models/src/commonMain/kotlin/com/squareup/invert/models/StatMetadata.kt
+++ b/invert-models/src/commonMain/kotlin/com/squareup/invert/models/StatMetadata.kt
@@ -8,9 +8,16 @@ import kotlinx.serialization.Serializable
  */
 @Serializable
 data class StatMetadata(
+  /** The unique key for this [Stat]. */
   val key: StatKey,
+  /** A short, human-readable description of this [Stat]. Use [documentation] field for detailed info. */
   val description: String,
+  /** The data type of this [Stat]. */
   val dataType: StatDataType,
+  /** This is used for grouping [Stat] by category. */
   val category: String = "Stats",
+  /** Metadata for the registered key/value "extras" for this [Stat]. */
   val extras: List<ExtraMetadata> = emptyList(),
+  /** Documentation on this [Stat] in Markdown format. */
+  val documentation: Markdown? = null,
 )

--- a/invert-models/src/commonMain/kotlin/com/squareup/invert/models/Typealiases.kt
+++ b/invert-models/src/commonMain/kotlin/com/squareup/invert/models/Typealiases.kt
@@ -3,6 +3,7 @@ package com.squareup.invert.models
 typealias DependencyId = String
 typealias ConfigurationName = String
 typealias GradlePluginId = String
+typealias Markdown = String
 typealias ModulePath = String
 typealias FileKey = String
 typealias OwnerName = String


### PR DESCRIPTION
This will be useful to provide more context about a given stat while still leaving the original "description" field short.