### PR TITLE
Removed global stats object and added "owner" to Code Reference Stat export

### DIFF
--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/report/js/InvertJsReportUtils.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/report/js/InvertJsReportUtils.kt
@@ -79,7 +79,6 @@ object InvertJsReportUtils {
             is Stat.CodeReferencesStat -> {
               stat.value.forEach { codeReference ->
                 val owner = codeReference.owner ?: moduleOwnerName
-                println("Adding for $owner, $codeReference")
                 val currentCountForOwner: Int = ownerToTotalCountForStat.getOrDefault(owner, 0)
                 ownerToTotalCountForStat[owner] = currentCountForOwner + 1
               }

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/report/js/InvertJsReportWriter.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/report/js/InvertJsReportWriter.kt
@@ -83,12 +83,6 @@ class InvertJsReportWriter(
     )
 
     writeJsFileInDir(
-      fileKey = JsReportFileKey.STATS.key,
-      serializer = StatsJsReportModel.serializer(),
-      value = allProjectsStatsData
-    )
-
-    writeJsFileInDir(
       fileKey = JsReportFileKey.CONFIGURATIONS.key,
       serializer = ConfigurationsJsReportModel.serializer(),
       value = InvertJsReportUtils.toCollectedConfigurations(allProjectsConfigurationsData)

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/report/json/InvertJsonReportWriter.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/report/json/InvertJsonReportWriter.kt
@@ -69,12 +69,6 @@ class InvertJsonReportWriter(
     )
 
     writeJsonFileInDir(
-      jsonFileKey = InvertPluginFileKey.STATS,
-      serializer = StatsJsReportModel.serializer(),
-      value = allProjectsStatsData
-    )
-
-    writeJsonFileInDir(
       jsonFileKey = InvertPluginFileKey.OWNERS,
       serializer = SetSerializer(CollectedOwnershipForProject.serializer()),
       value = allOwnersData

--- a/invert-models/src/commonMain/kotlin/com/squareup/invert/models/js/JsReportFileKey.kt
+++ b/invert-models/src/commonMain/kotlin/com/squareup/invert/models/js/JsReportFileKey.kt
@@ -17,7 +17,6 @@ enum class JsReportFileKey(
   METADATA("metadata", "Metadata"),
   CONFIGURATIONS("configurations", "Configurations"),
   STAT("stat", "Stat"),
-  STATS("stats", "Stats"),
   STAT_TOTALS("stat_totals", "Stat Totals");
 
   val jsFilename = "$key.js"

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/CollectedDataRepo.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/CollectedDataRepo.kt
@@ -53,10 +53,6 @@ class CollectedDataRepo(
   fun statData(statKey: StatKey): Flow<Map<StatKey, StatJsReportModel>?> = _statData
     .onEach { loadJsOfType(JsReportFileKey.STAT.key + "_$statKey") }
 
-  private val _statsData = MutableStateFlow<StatsJsReportModel?>(null)
-  val statsData: Flow<StatsJsReportModel?> = _statsData
-    .onEach { loadJsOfType(JsReportFileKey.STATS) }
-
   private val _combinedReportData: MutableStateFlow<DependenciesJsReportModel?> =
     MutableStateFlow(null)
   val combinedReportData: Flow<DependenciesJsReportModel?> = _combinedReportData.onEach {
@@ -120,10 +116,6 @@ class CollectedDataRepo(
 
   fun pluginsUpdated(pluginInfo: PluginsJsReportModel) {
     this._collectedPluginInfoReport.value = pluginInfo
-  }
-
-  fun statsUpdated(statsData: StatsJsReportModel) {
-    this._statsData.value = statsData
   }
 
   fun configurationsUpdated(configurationsData: ConfigurationsJsReportModel) {

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/ReportDataRepo.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/ReportDataRepo.kt
@@ -42,8 +42,6 @@ class ReportDataRepo(
       }
     }
 
-  val statsData: Flow<StatsJsReportModel?> = collectedDataRepo.statsData
-
   val historicalData: Flow<List<HistoricalData>?> = collectedDataRepo.historicalData.mapLatest { it }
 
   val statTotals: Flow<CollectedStatTotalsJsReportModel?> = collectedDataRepo.statTotals

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/ModuleDetailReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/ModuleDetailReportPage.kt
@@ -17,12 +17,8 @@ import com.squareup.invert.models.ConfigurationName
 import com.squareup.invert.models.DependencyId
 import com.squareup.invert.models.ModulePath
 import com.squareup.invert.models.OwnerName
-import com.squareup.invert.models.Stat
-import com.squareup.invert.models.StatKey
-import com.squareup.invert.models.StatMetadata
 import com.squareup.invert.models.utils.BuildSystemUtils
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapLatest
 import org.jetbrains.compose.web.dom.Br
 import org.jetbrains.compose.web.dom.H2
@@ -131,37 +127,6 @@ fun ModuleDetailComposable(
   val directDependenciesMap = directDependenciesMapOrig!!
 
   val pageTabs = mutableListOf<BootstrapTabData>()
-  pageTabs.add(
-    BootstrapTabData(tabName = "Stats") {
-      val statsForModule: Map<StatKey, Stat>? by reportDataRepo.statsData.map { it?.statsByModule?.get(navRoute.path) }
-        .collectAsState(null)
-
-      if (statsForModule != null && statInfos != null) {
-        val statsForModuleMap: Map<StatMetadata?, Stat> = statsForModule!!.mapKeys {
-          statInfos!!.first { statInfo -> statInfo.key == it.key }
-        }
-        BootstrapTable(
-          headers = listOf("Stat", "Value"),
-          rows = statsForModuleMap.filter { it.key != null && it.value is Stat.NumericStat }
-            .map { (key, value) ->
-              listOf(key!!.description, (value as Stat.NumericStat).value.toString())
-            },
-          types = listOf(String::class, Int::class),
-          maxResultsLimitConstant = MAX_RESULTS,
-          onItemClickCallback = {
-            navRouteRepo.pushNavRoute(
-              StatDetailNavRoute(
-                statKey = statInfos!!.first { statInfo -> statInfo.description == it[0] }.key
-              )
-            )
-          },
-          sortAscending = false,
-          sortByColumn = 0
-        )
-      }
-
-    })
-
   pageTabs.add(
     BootstrapTabData(tabName = "Direct Dependencies") {
       val allDirectDependencyToConfigurationEntries = mutableSetOf<DependencyIdAndConfiguration>()

--- a/invert-report/src/jsMain/kotlin/navigation/RemoteJsLoadingProgress.kt
+++ b/invert-report/src/jsMain/kotlin/navigation/RemoteJsLoadingProgress.kt
@@ -89,12 +89,6 @@ object RemoteJsLoadingProgress {
           )
         }
 
-        JsReportFileKey.STATS.key -> {
-          collectedDataRepo.statsUpdated(
-            InvertJson.decodeFromString(StatsJsReportModel.serializer(), json)
-          )
-        }
-
         JsReportFileKey.CONFIGURATIONS.key -> {
           collectedDataRepo.configurationsUpdated(
             InvertJson.decodeFromString(ConfigurationsJsReportModel.serializer(), json)


### PR DESCRIPTION
The combined "stats.json" file was just SO big it couldn't be written to disk for large projects.  Now we just write individual stat files.