### PR TITLE
Add support for filtering code references by values in 'extras'

### DIFF
--- a/invert-models/src/commonMain/kotlin/com/squareup/invert/models/ExtraMetadata.kt
+++ b/invert-models/src/commonMain/kotlin/com/squareup/invert/models/ExtraMetadata.kt
@@ -11,4 +11,6 @@ data class ExtraMetadata(
   val key: ExtraKey,
   val type: ExtraDataType,
   val description: String,
+  // Whether this metadata field should be filterable in the code references view.
+  val filterable: Boolean = false,
 )

--- a/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/CodeReferencesReportPage.kt
+++ b/invert-report/src/jsMain/kotlin/com/squareup/invert/common/pages/CodeReferencesReportPage.kt
@@ -22,6 +22,7 @@ import com.squareup.invert.models.ModulePath
 import com.squareup.invert.models.OwnerName
 import com.squareup.invert.models.StatKey
 import com.squareup.invert.models.StatMetadata
+import org.jetbrains.compose.web.css.CSSUnit
 import org.jetbrains.compose.web.dom.H1
 import org.jetbrains.compose.web.dom.H3
 import org.jetbrains.compose.web.dom.H4
@@ -46,6 +47,7 @@ data class CodeReferencesNavRoute(
   val module: String? = null,
   val treemap: Boolean? = null,
   val chart: Boolean? = null,
+  val extras: Map<String, String>? = null
 ) : BaseNavRoute(CodeReferencesReportPage.navPage) {
 
   override fun toSearchParams(): Map<String, String> = toParamsWithOnlyPageId(this)
@@ -65,6 +67,11 @@ data class CodeReferencesNavRoute(
       chart?.let {
         params[CHART_PARAM] = chart.toString()
       }
+      extras?.let {
+        it.forEach { (key, value) ->
+          params["extra_$key"] = value
+        }
+      }
     }
 
   companion object {
@@ -74,37 +81,51 @@ data class CodeReferencesNavRoute(
     private const val OWNER_PARAM = "owner"
     private const val MODULE_PARAM = "module"
     private const val TREEMAP_PARAM = "treemap"
+    private const val EXTRAS_PARAM_PREFIX = "extra_"
+
 
     fun parser(params: Map<String, String?>): NavRoute {
-      val statKey = params[STATKEY_PARAM]
-      val owner = params[OWNER_PARAM]?.trim()?.let {
-        if (it.isNotBlank()) {
-          it
-        } else {
-          null
+      var statKey: String? = null
+      var owner: String? = null
+      var module: String? = null
+      var treemap: Boolean? = null
+      var chart: Boolean? = null
+      var extras: MutableMap<String, String> = mutableMapOf()
+      params.forEach { (key, value) ->
+        val trimmedValue = value?.trim()?.let {
+          if (it.isNotBlank()) {
+            it
+          } else {
+            null
+          }
+        }
+        if (trimmedValue != null) {
+          when (key) {
+            STATKEY_PARAM -> {
+              statKey = trimmedValue
+            }
+            OWNER_PARAM -> {
+              owner = trimmedValue
+            }
+            MODULE_PARAM -> {
+              module = trimmedValue
+            }
+            TREEMAP_PARAM -> {
+              treemap = trimmedValue.toBoolean()
+            }
+            CHART_PARAM -> {
+              chart = trimmedValue.toBoolean()
+            }
+            else -> {
+              if (key.startsWith(EXTRAS_PARAM_PREFIX)) {
+                val extraKey = key.substring(EXTRAS_PARAM_PREFIX.length)
+                extras[extraKey] = trimmedValue
+              }
+            }
+          }
         }
       }
-      val module = params[MODULE_PARAM]?.trim()?.let {
-        if (it.isNotBlank()) {
-          it
-        } else {
-          null
-        }
-      }
-      val treemap = params[TREEMAP_PARAM]?.trim()?.let {
-        if (it.isNotBlank()) {
-          it.toBoolean()
-        } else {
-          null
-        }
-      }
-      val chart = params[CHART_PARAM]?.trim()?.let {
-        if (it.isNotBlank()) {
-          it.toBoolean()
-        } else {
-          null
-        }
-      }
+
       return if (statKey == null) {
         AllStatsNavRoute()
       } else {
@@ -114,6 +135,7 @@ data class CodeReferencesNavRoute(
           module = module,
           treemap = treemap,
           chart = chart,
+          extras = extras.let { if (it.isEmpty()) null else it }
         )
       }
     }
@@ -293,6 +315,18 @@ fun CodeReferencesComposable(
         true
       }
     }
+    // Filter by extras
+    .filter { ownerAndCodeReference: ModuleOwnerAndCodeReference ->
+      val codeReference = ownerAndCodeReference.codeReference
+      val extras = codeReferencesNavRoute.extras ?: mapOf()
+      if (extras.isEmpty()) {
+        true
+      } else {
+        extras.all { (key, value) ->
+          codeReference.extras[key] == value
+        }
+      }
+    }
 
   if (codeReferencesNavRoute.treemap == true) {
     BootstrapRow {
@@ -381,6 +415,47 @@ fun CodeReferencesComposable(
               module = it?.value
             )
           )
+        }
+      }
+    }
+  }
+  val filterableExtras = currentStatMetadata.extras.filter { it.filterable }
+  if (filterableExtras.isNotEmpty()) {
+    BootstrapRow {
+      filterableExtras.forEach { extra ->
+        BootstrapColumn(6) {
+          H3 {
+            Text("Filter by ${extra.description}")
+            BootstrapSelectDropdown(
+              placeholderText = "-- All Values --",
+              currentValue = codeReferencesNavRoute.extras?.get(extra.key),
+              options = allCodeReferencesForStat.mapNotNull {
+                it.codeReference.extras[extra.key]
+              }.toSet().map {
+                BootstrapSelectOption(
+                  value = it,
+                  displayText = it,
+                )
+              }.sortedBy { it.displayText }
+            ) {
+              val value = it?.value
+              var newExtras: Map<String, String>? = null
+              val currentExtras = codeReferencesNavRoute.extras ?: mapOf()
+              if (value != null) {
+                newExtras = currentExtras + mapOf(extra.key to value)
+              } else {
+                newExtras = currentExtras.minus(extra.key)
+                if (newExtras.isEmpty()) {
+                  newExtras = null
+                }
+              }
+              navRouteRepo.pushNavRoute(
+                codeReferencesNavRoute.copy(
+                  extras = newExtras
+                )
+              )
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Adds additional filter drop downs to the code references view for specific extras that are marked as `filterable`.

<img width="1153" alt="Screenshot 2025-04-25 at 11 09 59 AM" src="https://github.com/user-attachments/assets/cb839a7a-bbd8-4e9e-942f-654895b73059" />

<img width="748" alt="Screenshot 2025-04-25 at 11 10 09 AM" src="https://github.com/user-attachments/assets/237e0cf0-c7d3-4825-b89e-d0f2a77363db" />
