### PR TITLE
Bug Fix: Owner and module weren't getting added correctly.

### DIFF
--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/CollectedStatAggregator.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/CollectedStatAggregator.kt
@@ -63,16 +63,18 @@ object CollectedStatAggregator {
             synchronized(allCodeReferencesForStatWithProjectPathExtra) {
               allCodeReferencesForStatWithProjectPathExtra.addAll(
                 collectedCodeReferenceStat.value.map { codeReference: Stat.CodeReferencesStat.CodeReference ->
-                  // Adding addition "extra" field named "project"
-                  codeReference.copy(
-                    extras = codeReference.extras.apply {
-                      plus(MODULE_EXTRA_METADATA.key to collectedStatsForProject.path)
-                      moduleToOwnerMap[collectedStatsForProject.path]?.let { ownerName ->
-                        plus(
-                          OWNER_EXTRA_METADATA.key to ownerName
-                        )
-                      }
+                  // Use the owner from the code reference if it exists, otherwise use the module's owner
+                  val codeReferenceOwner = codeReference.owner ?: moduleToOwnerMap[collectedStatsForProject.path]
+
+                  // Updating the extras to include the "module" and "owner"
+                  val updatedExtras = codeReference.extras.toMutableMap().apply {
+                    this[MODULE_EXTRA_METADATA.key] = collectedStatsForProject.path
+                    if (codeReferenceOwner != null) {
+                      this[OWNER_EXTRA_METADATA.key] = codeReferenceOwner
                     }
+                  }
+                  codeReference.copy(
+                    extras = updatedExtras
                   )
                 }
               )


### PR DESCRIPTION
1. We weren't actually updating the `extras` appropriately. (Didn't make the `Map` mutable and add to it)
2. We we would have only used the module's owner, but now if a code reference specifies an owner, it will use that override.


```json
{
    "metadata": {
        "key": "android_tests",
        "description": "Android @Test(s)",
        "dataType": "CODE_REFERENCES",
        "category": "Android Tests",
        "extras": [
            {
                "key": "module",
                "type": "STRING",
                "description": "Module"
            },
            {
                "key": "owner",
                "type": "STRING",
                "description": "Owner"
            }
        ]
    },
    "values": [
        {
            "filePath": "apps/somemodule/src/main/SomeTest.kt",
            "startLine": 78,
            "endLine": 99,
            "extras": {
                "module": ":somemodule",
                "owner": "SomeOwner"
            },
            "code": "...",
        },
    ]
}
```