### PR TITLE
Update stat to include a new uniqueId based from filepath and startline

### DIFF
--- a/invert-models/src/commonMain/kotlin/com/squareup/invert/models/Stat.kt
+++ b/invert-models/src/commonMain/kotlin/com/squareup/invert/models/Stat.kt
@@ -45,6 +45,7 @@ sealed interface Stat {
       val extras: Map<ExtraKey, String> = emptyMap(),
       val code: String? = null,
       val owner: OwnerName? = null,
+      val uniqueId: String = "$filePath:${startLine}"
     )
   }
 }


### PR DESCRIPTION
This pull request introduces a small but significant change to the `Stat` interface in the `invert-models` module. The change adds a new property, `uniqueId`, to the `Stat` data class, which is constructed using the `filePath` and `startLine` values.

* [`invert-models/src/commonMain/kotlin/com/squareup/invert/models/Stat.kt`](diffhunk://#diff-770f7935cea7e7faa37389841d6de9bde6618780f2afc82e9678507152d533c3R48): Added a `uniqueId` property to the `Stat` data class to uniquely identify instances based on their file path and starting line.