### PR TITLE
Bump release to 0.0.4-dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 _2024-11-27_
 
+## Version 0.0.4-dev
+* Added uniqueIdentifier to `CodeReference` to allow for easier linking.
+* Added Sarif support to export `CodeReference`s in the Sarif format.
+* Simplified the "Stat Detail" page to only include a single statKey as a param instead of a list.  We weren't really using that feature anyways.
+* Added collectors to init scripts. Also publishing all artifacts.
+* Added new 'configureInvert' callback before invert is loaded.
+* Added line chart support.
+* Updated CodeReferences and Owner Breakdown pages.
+* Compute totals by module and by ownership.
+* Added sorting for numeric extras!
+* Added a new AllOwners field to the InvertOwnershipCollector
+* Added Tech Debt Page w/embed view
+**Full Changelog**: https://github.com/square/invert/compare/0.0.3-dev...0.0.4-dev
+
 ## Version 0.0.3-dev
 * Added in the ability to attach "extras" key/value pairs to a `CodeReference`
 * Renamed `gradlePath` -> `modulePath` to be more general.

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.jvmargs=-Xmx16g
 kotlin.code.style=official
 android.useAndroidX=true
 group=com.squareup.invert
-version=0.0.4-dev-SNAPSHOT
+version=0.0.4-dev


### PR DESCRIPTION
This pull request introduces updates for the upcoming `0.0.4-dev` release, including feature additions, improvements to existing functionality, and version updates. The most critical changes focus on enhancing the `CodeReference` functionality, simplifying pages, and adding new features like line chart support and a Tech Debt Page.

### Release-related changes:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R18): Added detailed notes for the `0.0.4-dev` release, including new features such as `uniqueIdentifier` for `CodeReference`, Sarif export support, and a Tech Debt Page.
* [`gradle.properties`](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L5-R5): Updated the version from `0.0.4-dev-SNAPSHOT` to `0.0.4-dev`.