### PR TITLE
Fix issue with Extras Metadata object and add test case.

### DIFF
--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/report/sarif/InvertSarifUtils.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/report/sarif/InvertSarifUtils.kt
@@ -130,7 +130,11 @@ fun StatMetadata.asReportingDescriptor(shortDescription: String = ""): Reporting
         properties = PropertyBag(
             value = mapOf(
                 SarifKey.DESCRIPTION to description,
-                SarifKey.EXTRAS to extras,
+                SarifKey.EXTRAS to extras.map {
+                    mapOf(
+                        it.key to it.description
+                    )
+                },
                 SarifKey.CATEGORIES to category,
                 SarifKey.TITLE to title
             )

--- a/invert-gradle-plugin/src/test/kotlin/com/squareup/invert/internal/report/sarif/InvertSarifReportWriterTest.kt
+++ b/invert-gradle-plugin/src/test/kotlin/com/squareup/invert/internal/report/sarif/InvertSarifReportWriterTest.kt
@@ -3,6 +3,8 @@ package com.squareup.invert.internal.report.sarif
 import com.squareup.invert.internal.InvertFileUtils
 import com.squareup.invert.internal.models.InvertPluginFileKey
 import com.squareup.invert.logging.InvertLogger
+import com.squareup.invert.models.ExtraDataType
+import com.squareup.invert.models.ExtraMetadata
 import com.squareup.invert.models.Stat
 import com.squareup.invert.models.StatDataType
 import com.squareup.invert.models.StatMetadata
@@ -99,7 +101,14 @@ class InvertSarifReportWriterTest {
         val codeRefStatInfo = StatMetadata(
             key = "test_stat",
             description = "Test Stat",
-            dataType = StatDataType.CODE_REFERENCES
+            dataType = StatDataType.CODE_REFERENCES,
+            extras = listOf(
+                ExtraMetadata(
+                    key = "extra_info",
+                    type = ExtraDataType.STRING,
+                    description = "Extra information for test stat"
+                )
+            )
         )
 
         val codeReferences = listOf(


### PR DESCRIPTION
This pull request introduces enhancements to the handling of `extras` in SARIF reporting and updates related test cases to support these changes. The most important changes include modifying the `extras` structure in the SARIF report generation and adding new test data for validation.

### SARIF reporting enhancements:

* [`invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/report/sarif/InvertSarifUtils.kt`](diffhunk://#diff-8382b85ba153c478810e53ba52cd415f7ab7681d234ba875991985746d1ed0e2L133-R137): Updated the `extras` property in the SARIF report generation to transform each `ExtraMetadata` item into a key-description map for improved clarity in reporting.

### Test case updates:

* `invert-gradle-plugin/src/test/kotlin/com/squareup/invert/internal/report/sarif/InvertSarifReportWriterTest.kt`: 
  - Added imports for `ExtraDataType` and `ExtraMetadata` to support the new `extras` structure.
  - Updated the `StatMetadata` test data to include an `extras` list with `ExtraMetadata` objects for validating the new SARIF reporting behavior.