### PR TITLE
Allow owner/module to be used in properties sarif

### DIFF
--- a/invert-collectors/src/main/kotlin/com/squareup/invert/collectors/contains/InvertContainsStatCollector.kt
+++ b/invert-collectors/src/main/kotlin/com/squareup/invert/collectors/contains/InvertContainsStatCollector.kt
@@ -4,6 +4,8 @@ import com.squareup.invert.CollectedStat
 import com.squareup.invert.InvertCollectContext
 import com.squareup.invert.StatCollector
 import com.squareup.invert.collectors.internal.wrapCodeForMarkdown
+import com.squareup.invert.models.ExtraDataType
+import com.squareup.invert.models.ExtraMetadata
 import com.squareup.invert.models.Markdown
 import com.squareup.invert.models.Stat
 import com.squareup.invert.models.StatDataType
@@ -51,6 +53,13 @@ open class InvertContainsStatCollector(
             title = statTitle,
             description = statDescription ?: statTitle,
             dataType = StatDataType.CODE_REFERENCES,
+            extras = listOf(
+              ExtraMetadata(
+                key = "filePredicate",
+                type = ExtraDataType.STRING,
+                description = "Predicate to filter files for this stat collector"
+              )
+            )
           ),
           stat = Stat.CodeReferencesStat(codeReferences)
         )

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/CollectedStatAggregator.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/CollectedStatAggregator.kt
@@ -108,7 +108,9 @@ object CollectedStatAggregator {
             "code_references_${statMetadata.key}.sarif"
           ),
           metadata = statMetadata,
-          values = allCodeReferencesForStatWithProjectPathExtra
+          values = allCodeReferencesForStatWithProjectPathExtra,
+          moduleExtraKey = MODULE_EXTRA_METADATA,
+            ownerExtraKey = OWNER_EXTRA_METADATA,
         )
       }
     }

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/CollectedStatAggregator.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/CollectedStatAggregator.kt
@@ -109,8 +109,8 @@ object CollectedStatAggregator {
           ),
           metadata = statMetadata,
           values = allCodeReferencesForStatWithProjectPathExtra,
-          moduleExtraKey = MODULE_EXTRA_METADATA,
-            ownerExtraKey = OWNER_EXTRA_METADATA,
+          moduleExtraKey = MODULE_EXTRA_METADATA.key,
+          ownerExtraKey = OWNER_EXTRA_METADATA.key,
         )
       }
     }

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/report/sarif/InvertSarifReportWriter.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/report/sarif/InvertSarifReportWriter.kt
@@ -76,8 +76,8 @@ class InvertSarifReportWriter(
             metadata: StatMetadata,
             fileName: File,
             description: String,
-            moduleExtraKey: ExtraMetadata,
-            ownerExtraKey: ExtraMetadata,
+            moduleExtraKey: String,
+            ownerExtraKey: String,
         ) {
             if (!fileName.exists()) {
                 fileName.parentFile.mkdirs()
@@ -87,8 +87,8 @@ class InvertSarifReportWriter(
             val results = values.map {
                 it.toSarifResult(
                     metadata.key,
-                    modulePath = it.extras.getOrElse(moduleExtraKey.key) { null },
-                    ownerInfo = it.extras.getOrElse(ownerExtraKey.key) { OwnerInfo.UNOWNED }
+                    modulePath = it.extras.getOrElse(moduleExtraKey) { null },
+                    ownerInfo = it.extras.getOrElse(ownerExtraKey) { OwnerInfo.UNOWNED }
                 )
             }
             val rule = metadata.asReportingDescriptor(shortDescription = description)

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/report/sarif/InvertSarifReportWriter.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/report/sarif/InvertSarifReportWriter.kt
@@ -1,8 +1,11 @@
 package com.squareup.invert.internal.report.sarif
 
 import com.squareup.invert.internal.InvertFileUtils
+import com.squareup.invert.internal.models.CollectedOwnershipForProject
 import com.squareup.invert.internal.models.InvertPluginFileKey
 import com.squareup.invert.logging.InvertLogger
+import com.squareup.invert.models.ExtraMetadata
+import com.squareup.invert.models.OwnerInfo
 import com.squareup.invert.models.Stat
 import com.squareup.invert.models.StatMetadata
 import com.squareup.invert.models.js.StatsJsReportModel
@@ -72,14 +75,22 @@ class InvertSarifReportWriter(
             values: List<Stat.CodeReferencesStat.CodeReference>,
             metadata: StatMetadata,
             fileName: File,
-            description: String
+            description: String,
+            moduleExtraKey: ExtraMetadata,
+            ownerExtraKey: ExtraMetadata,
         ) {
             if (!fileName.exists()) {
                 fileName.parentFile.mkdirs()
                 fileName.createNewFile()
             }
 
-            val results = values.map { it.toSarifResult(metadata.key, modulePath = null) }
+            val results = values.map {
+                it.toSarifResult(
+                    metadata.key,
+                    modulePath = it.extras.getOrElse(moduleExtraKey.key) { null },
+                    ownerInfo = it.extras.getOrElse(ownerExtraKey.key) { OwnerInfo.UNOWNED }
+                )
+            }
             val rule = metadata.asReportingDescriptor(shortDescription = description)
             val sarifSchema = createSarifSchemaFromResults(rule = rule, results = results)
             val sarifJson = SarifSerializer.toMinifiedJson(sarifSchema)

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/report/sarif/InvertSarifUtils.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/report/sarif/InvertSarifUtils.kt
@@ -58,7 +58,8 @@ fun Stat.asSarifResult(
 @VisibleForTesting
 fun Stat.CodeReferencesStat.CodeReference.toSarifResult(
     key: StatKey,
-    modulePath: ModulePath?
+    modulePath: ModulePath?,
+    ownerInfo: String = OwnerInfo.UNOWNED
 ): SarifResult = SarifResult(
     ruleID = key,
     message = Message(text = code),
@@ -81,8 +82,8 @@ fun Stat.CodeReferencesStat.CodeReference.toSarifResult(
     ),
     properties = PropertyBag(
         value = mapOf(
-            SarifKey.OWNER to (owner ?: OwnerInfo.UNOWNED),
-            SarifKey.MODULE to modulePath,
+            SarifKey.OWNER to (owner ?: ownerInfo),
+            SarifKey.MODULE to (modulePath),
             SarifKey.UNIQUE_ID to uniqueId,
         )
     ),

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/report/sarif/InvertSarifUtils.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/report/sarif/InvertSarifUtils.kt
@@ -45,7 +45,7 @@ fun Stat.asSarifResult(
 ): List<SarifResult> = when (this) {
     is Stat.CodeReferencesStat -> value.map {
         it.toSarifResult(
-            key = key, modulePath = module
+            key = key, modulePath = module, ownerInfo = it.owner ?: OwnerInfo.UNOWNED
         )
     }
     // No support for other stat types in SARIF
@@ -59,7 +59,7 @@ fun Stat.asSarifResult(
 fun Stat.CodeReferencesStat.CodeReference.toSarifResult(
     key: StatKey,
     modulePath: ModulePath?,
-    ownerInfo: String = OwnerInfo.UNOWNED
+    ownerInfo: String
 ): SarifResult = SarifResult(
     ruleID = key,
     message = Message(text = code),

--- a/invert-gradle-plugin/src/test/kotlin/com/squareup/invert/internal/report/sarif/InvertSarifReportWriterTest.kt
+++ b/invert-gradle-plugin/src/test/kotlin/com/squareup/invert/internal/report/sarif/InvertSarifReportWriterTest.kt
@@ -87,16 +87,8 @@ class InvertSarifReportWriterTest {
             metadata = metadata,
             fileName = testFile,
             description = "Test Description",
-            moduleExtraKey = ExtraMetadata(
-                key = "module",
-                type = ExtraDataType.STRING,
-                description = "Module information"
-            ),
-            ownerExtraKey = ExtraMetadata(
-                key = "owner",
-                type = ExtraDataType.STRING,
-                description = "Owner information"
-            )
+            moduleExtraKey = "module",
+            ownerExtraKey = "owner"
         )
 
         // Then
@@ -143,16 +135,8 @@ class InvertSarifReportWriterTest {
             metadata = metadata,
             fileName = testFile,
             description = "Test Description",
-            moduleExtraKey = ExtraMetadata(
-                key = "module",
-                type = ExtraDataType.STRING,
-                description = "Module information"
-            ),
-            ownerExtraKey = ExtraMetadata(
-                key = "owner",
-                type = ExtraDataType.STRING,
-                description = "Owner information"
-            )
+            moduleExtraKey = "module",
+            ownerExtraKey = "owner"
         )
 
         // Then

--- a/invert-gradle-plugin/src/test/kotlin/com/squareup/invert/internal/report/sarif/InvertSarifReportWriterTest.kt
+++ b/invert-gradle-plugin/src/test/kotlin/com/squareup/invert/internal/report/sarif/InvertSarifReportWriterTest.kt
@@ -86,7 +86,17 @@ class InvertSarifReportWriterTest {
             values = codeReferences,
             metadata = metadata,
             fileName = testFile,
-            description = "Test Description"
+            description = "Test Description",
+            moduleExtraKey = ExtraMetadata(
+                key = "module",
+                type = ExtraDataType.STRING,
+                description = "Module information"
+            ),
+            ownerExtraKey = ExtraMetadata(
+                key = "owner",
+                type = ExtraDataType.STRING,
+                description = "Owner information"
+            )
         )
 
         // Then
@@ -95,6 +105,65 @@ class InvertSarifReportWriterTest {
         assertTrue(content.contains("\"id\":\"test_stat\""), "Should contain rule ID")
         assertTrue(content.contains("\"text\":\"test code\""), "Should contain code snippet")
         assertTrue(content.contains("\"uri\":\"test.kt\""), "Should contain file path")
+    }
+
+
+    @Test
+    fun `test writeToSarifReport uses extras owner if code stat owner doesnt exist`() {
+        // Given
+        val testFile = File(testDir, "test.sarif")
+        val codeReferences = listOf(
+            Stat.CodeReferencesStat.CodeReference(
+                filePath = "test.kt",
+                startLine = 1,
+                endLine = 10,
+                code = "test code",
+                owner = "codeStatOwner"
+            ),
+            Stat.CodeReferencesStat.CodeReference(
+                filePath = "test.kt",
+                startLine = 1,
+                endLine = 10,
+                code = "test code",
+                extras =  mapOf(
+                    "owner" to "testOwner",
+                    "module" to "testModule"
+                )
+            )
+        )
+        val metadata = StatMetadata(
+            key = "test_stat",
+            description = "Test Stat",
+            dataType = StatDataType.CODE_REFERENCES
+        )
+
+        // When
+        InvertSarifReportWriter.writeToSarifReport(
+            values = codeReferences,
+            metadata = metadata,
+            fileName = testFile,
+            description = "Test Description",
+            moduleExtraKey = ExtraMetadata(
+                key = "module",
+                type = ExtraDataType.STRING,
+                description = "Module information"
+            ),
+            ownerExtraKey = ExtraMetadata(
+                key = "owner",
+                type = ExtraDataType.STRING,
+                description = "Owner information"
+            )
+        )
+
+        // Then
+        assertTrue(testFile.exists(), "SARIF file should be created")
+        val content = testFile.readText()
+        assertTrue(content.contains("\"id\":\"test_stat\""), "Should contain rule ID")
+        assertTrue(content.contains("\"text\":\"test code\""), "Should contain code snippet")
+        assertTrue(content.contains("\"uri\":\"test.kt\""), "Should contain file path")
+        assertTrue(content.contains("\"owner\":\"testOwner\""), "Should contain owner information")
+        assertTrue(content.contains("\"owner\":\"codeStatOwner\""), "Should contain owner information")
+        assertTrue(content.contains("\"module\":\"testModule\""), "Should contain module information")
     }
 
     private fun createTestStatsData(): StatsJsReportModel {


### PR DESCRIPTION
This will allow the owner and module information to be pulled from the extras if none exists.