### PR TITLE
Fix Kotlin 2.1.21 webpack resources issue

### DIFF
--- a/invert-report/webpack.config.d/no-clean.js
+++ b/invert-report/webpack.config.d/no-clean.js
@@ -1,0 +1,6 @@
+// This prevents the webpack output from clearing/cleaning the directory first
+// Without this the other files are deleted.
+config.output = {
+  ...config.output,
+  clean: false
+};

--- a/invert-report/webpack.config.d/no-clean.js
+++ b/invert-report/webpack.config.d/no-clean.js
@@ -1,5 +1,8 @@
+// Custom webpack config
+// https://kotlinlang.org/docs/js-project-setup.html#custom-webpack-configuration
+
 // This prevents the webpack output from clearing/cleaning the directory first
-// Without this the other files are deleted.
+// This matches the behavior from Kotlin 2.0.0.
 config.output = {
   ...config.output,
   clean: false


### PR DESCRIPTION
Kotlin JS + Webpack somehow changed between Kotlin version 2.0.0 and 2.1.21.

We need this additional webpack config file to tell webpack to not clear the entire directory before outputting the files.  This allows us to match our old behavior and avoid clearing out the resources we intend to keep.