### PR TITLE
Release 0.0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ invert {
         configurationNames
     }
     ownershipCollector(<<ownership collector instance>>)
+    // Optional: disable only the aggregate `sarif/stats.sarif` artifact for very large repos.
+    // Per-stat `sarif/code_references_*.sarif` artifacts are still generated.
+    aggregateStatsSarifReport(false)
 }
 ```
 

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/InvertExtension.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/InvertExtension.kt
@@ -57,12 +57,20 @@ open class InvertExtension(project: Project) {
   @get:Input
   internal val historicalDataFileProperty = objects.property<String?>(String::class.java)
 
+  @get:Input
+  internal val aggregateStatsSarifReportEnabledProperty =
+    objects.property(Boolean::class.java).convention(true)
+
   fun ownershipCollector(ownershipCollector: InvertOwnershipCollector) {
     ownershipCollectorProperty.set(ownershipCollector)
   }
 
   fun historicalData(historicalDataFile: String) {
     this.historicalDataFileProperty.set(historicalDataFile)
+  }
+
+  fun aggregateStatsSarifReport(enabled: Boolean) {
+    aggregateStatsSarifReportEnabledProperty.set(enabled)
   }
 
   fun includeSubproject(invertShouldIncludeSubProject: (subproject: Project) -> Boolean) {
@@ -101,6 +109,10 @@ open class InvertExtension(project: Project) {
 
   internal fun getHistoricalDataFilePath(): String? {
     return historicalDataFileProperty.orNull
+  }
+
+  internal fun isAggregateStatsSarifReportEnabled(): Boolean {
+    return aggregateStatsSarifReportEnabledProperty.getOrElse(true)
   }
 
   internal fun getStatCollectors(): Collection<StatCollector> {

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/report/InvertReportWriter.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/report/InvertReportWriter.kt
@@ -37,7 +37,8 @@ class InvertReportWriter(
     reportMetadata: MetadataJsReportModel,
     collectedData: InvertCombinedCollectedData,
     historicalData: Set<HistoricalData>,
-    techDebtInitiatives: List<TechDebtInitiative>
+    techDebtInitiatives: List<TechDebtInitiative>,
+    aggregateStatsSarifReportEnabled: Boolean = true,
   ) {
     val collectedOwners: Set<CollectedOwnershipForProject> = collectedData.collectedOwners
     val collectedStats: Set<CollectedStatsForProject> = collectedData.collectedStats
@@ -78,10 +79,14 @@ class InvertReportWriter(
       historicalData = historicalDataWithCurrent,
     )
 
-    // Include all stats into one SARIF report.
-    InvertSarifReportWriter(invertLogger, rootBuildReportsDir).createInvertSarifReport(
-      allProjectsStatsData = allProjectsStatsData
-    )
+    if (aggregateStatsSarifReportEnabled) {
+      // Include all stats into one SARIF report.
+      InvertSarifReportWriter(invertLogger, rootBuildReportsDir).createInvertSarifReport(
+        allProjectsStatsData = allProjectsStatsData
+      )
+    } else {
+      invertLogger.info("Skipping aggregate stats.sarif generation.")
+    }
 
     // HTML/JS Report
     InvertJsReportWriter(invertLogger, rootBuildReportsDir).createInvertHtmlReport(

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/tasks/InvertTask.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/tasks/InvertTask.kt
@@ -85,6 +85,9 @@ abstract class InvertTask : DefaultTask() {
   @get:Input
   abstract val mavenRepoUrls: ListProperty<String>
 
+  @get:Input
+  abstract val aggregateStatsSarifReportEnabled: Property<Boolean>
+
   @get:OutputDirectory
   abstract val rootBuildReportsDir: DirectoryProperty
 
@@ -151,6 +154,7 @@ abstract class InvertTask : DefaultTask() {
         collectedData = allCollectedData,
         historicalData = historicalData,
         techDebtInitiatives = techDebtInitiatives ?: emptyList(),
+        aggregateStatsSarifReportEnabled = aggregateStatsSarifReportEnabled.get(),
       )
     }
   }
@@ -179,6 +183,7 @@ abstract class InvertTask : DefaultTask() {
     this.statCollectors = extension.getStatCollectors().toList()
     this.techDebtInitiatives = extension.getTechDebtInitiatives().toList()
     this.ownershipCollector = extension.getOwnershipCollector()
+    this.aggregateStatsSarifReportEnabled.set(extension.isAggregateStatsSarifReportEnabled())
 
     this.mavenRepoUrls.set(
       project.rootProject.buildscript.repositories

--- a/invert-gradle-plugin/src/test/kotlin/com/squareup/invert/internal/report/InvertReportWriterTest.kt
+++ b/invert-gradle-plugin/src/test/kotlin/com/squareup/invert/internal/report/InvertReportWriterTest.kt
@@ -102,6 +102,31 @@ class InvertReportWriterTest {
   }
 
   @Test
+  fun `test writeProjectData can skip aggregate stats sarif while preserving code reference sarif`() {
+    // Given
+    val writer = InvertReportWriter(logger, testDir)
+    val testMetadata = createTestMetadata()
+    val testCollectedData = createCollectedDataWithCodeReferences()
+
+    // When
+    writer.writeProjectData(
+      reportMetadata = testMetadata,
+      collectedData = testCollectedData,
+      historicalData = emptySet(),
+      techDebtInitiatives = emptyList(),
+      aggregateStatsSarifReportEnabled = false,
+    )
+
+    // Then
+    val sarifDir = File(testDir, "sarif")
+    assertFalse(File(sarifDir, "stats.sarif").exists(), "Aggregate stats SARIF file should not be created")
+    assertTrue(
+      File(sarifDir, "code_references_test_code_ref_stat.sarif").exists(),
+      "Code references SARIF file should still be created"
+    )
+  }
+
+  @Test
   fun `test writeProjectData includes module and owner in code reference extras`() {
     // Given
     val writer = InvertReportWriter(logger, testDir)


### PR DESCRIPTION
## Summary
- add an opt-out for aggregate `sarif/stats.sarif` generation while preserving per-stat `code_references_*.sarif` exports
- update the public docs and changelog for the `0.0.12` release
- prepare the branch for release publication from `main`

## Testing
- `./gradlew assemble check --no-daemon --stacktrace`