### PR TITLE
Release 0.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Version 0.0.12
+
+* Add a Gradle DSL option to disable aggregate `stats.sarif` generation while preserving per-stat `code_references_*.sarif` exports.
+
+**Full Changelog**: https://github.com/square/invert/compare/0.0.11...0.0.12
+
 ## Version 0.0.11
 
 * Expose owner details metadata through `InvertAllCollectedDataRepo.getOwners()` for collector aggregation enrichment.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Invert is a Gradle Plugin with a dynamic web report that lets you gain insights 
 ```
 // Root build.gradle
 plugins {
-    id("com.squareup.invert") version "0.0.11"
+    id("com.squareup.invert") version "0.0.12"
 }
 repositories {
     mavenCentral() // Released Versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx16g
 kotlin.code.style=official
 android.useAndroidX=true
 group=com.squareup.invert
-version=0.0.12-SNAPSHOT
+version=0.0.12
 
 # https://kotlinlang.org/docs/dokka-migration.html#enable-migration-helpers
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled


### PR DESCRIPTION
## Summary
- cut the `0.0.12` release from the current snapshot line
- document the new aggregate `stats.sarif` opt-out in the changelog and README
- prepare `main` to publish the stable artifact from CI

## Included in 0.0.12
- add an opt-out for aggregate `sarif/stats.sarif` generation while preserving per-stat `code_references_*.sarif` exports

## Testing
- `./gradlew assemble check --no-daemon --stacktrace`