### PR TITLE
Stream SARIF serialization with sarif4k 0.7.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,13 +5,13 @@ import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 buildscript {
   repositories {
-    mavenLocal()
     mavenCentral()
     google()
     gradlePluginPortal()
     maven {
       url = uri("https://oss.sonatype.org/service/local/repositories/snapshots/content")
     } // SNAPSHOT Versions for statik
+    mavenLocal()
   }
 }
 
@@ -23,6 +23,7 @@ allprojects {
     maven {
       url = uri("https://oss.sonatype.org/service/local/repositories/snapshots/content")
     } // SNAPSHOT Versions for statik
+    mavenLocal()
   }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ jetbrains-compose = "1.8.0"
 ksp = "2.1.21-2.0.2"
 truth = "1.4.4"
 dokka = "2.0.0"
-sarif4k = "0.6.0"
+sarif4k = "0.7.0-SNAPSHOT"
 okio = "3.16.2"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ jetbrains-compose = "1.8.0"
 ksp = "2.1.21-2.0.2"
 truth = "1.4.4"
 dokka = "2.0.0"
-sarif4k = "0.7.0-SNAPSHOT"
+sarif4k = "0.7.0"
 okio = "3.16.2"
 
 [libraries]

--- a/invert-gradle-plugin/build.gradle.kts
+++ b/invert-gradle-plugin/build.gradle.kts
@@ -37,6 +37,11 @@ tasks.named<Jar>("sourcesJar") {
   duplicatesStrategy = DuplicatesStrategy.INCLUDE
 }
 
+fun ExternalModuleDependency.excludeTransitiveKotlinDependencies() {
+  exclude(group = "org.jetbrains.kotlin")
+  exclude(group = "org.jetbrains.kotlinx")
+}
+
 dependencies {
   api(gradleApi())
   // Explicit JVM configuration is needed for composite builds (includeBuild) to correctly
@@ -47,25 +52,11 @@ dependencies {
   implementation(libs.kotlinx.coroutines.core)
   implementation(libs.okio)
   compileOnly(libs.detekt.sarif4k) {
-    exclude(group = "org.jetbrains.kotlin")
-    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-io-core")
-    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-io-core-jvm")
-    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-serialization-bom")
-    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-serialization-core")
-    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-serialization-core-jvm")
-    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-serialization-json")
-    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-serialization-json-jvm")
+    excludeTransitiveKotlinDependencies()
   }
   runtimeOnly(libs.detekt.sarif4k)
   testCompileOnly(libs.detekt.sarif4k) {
-    exclude(group = "org.jetbrains.kotlin")
-    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-io-core")
-    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-io-core-jvm")
-    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-serialization-bom")
-    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-serialization-core")
-    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-serialization-core-jvm")
-    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-serialization-json")
-    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-serialization-json-jvm")
+    excludeTransitiveKotlinDependencies()
   }
 
   testImplementation(libs.kotlin.test)

--- a/invert-gradle-plugin/build.gradle.kts
+++ b/invert-gradle-plugin/build.gradle.kts
@@ -46,7 +46,27 @@ dependencies {
   implementation(libs.kotlinx.serialization.json)
   implementation(libs.kotlinx.coroutines.core)
   implementation(libs.okio)
-  implementation(libs.detekt.sarif4k)
+  compileOnly(libs.detekt.sarif4k) {
+    exclude(group = "org.jetbrains.kotlin")
+    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-io-core")
+    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-io-core-jvm")
+    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-serialization-bom")
+    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-serialization-core")
+    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-serialization-core-jvm")
+    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-serialization-json")
+    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-serialization-json-jvm")
+  }
+  runtimeOnly(libs.detekt.sarif4k)
+  testCompileOnly(libs.detekt.sarif4k) {
+    exclude(group = "org.jetbrains.kotlin")
+    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-io-core")
+    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-io-core-jvm")
+    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-serialization-bom")
+    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-serialization-core")
+    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-serialization-core-jvm")
+    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-serialization-json")
+    exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-serialization-json-jvm")
+  }
 
   testImplementation(libs.kotlin.test)
 }

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/report/sarif/InvertSarifReportWriter.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/report/sarif/InvertSarifReportWriter.kt
@@ -14,8 +14,7 @@ import io.github.detekt.sarif4k.SarifSerializer
 import io.github.detekt.sarif4k.Tool
 import io.github.detekt.sarif4k.ToolComponent
 import io.github.detekt.sarif4k.Version
-import okio.buffer
-import okio.sink
+import io.github.detekt.sarif4k.toMinifiedJson
 import java.io.File
 import io.github.detekt.sarif4k.Result as SarifResult
 
@@ -46,8 +45,8 @@ class InvertSarifReportWriter(
             filename = jsonFileKey.filename
         )
 
-        sarifFile.sink().buffer().use { sink ->
-            sink.writeUtf8(SarifSerializer.toMinifiedJson(sarif))
+        sarifFile.outputStream().use { output ->
+            SarifSerializer.toMinifiedJson(sarif, output)
         }
     }
 
@@ -94,9 +93,8 @@ class InvertSarifReportWriter(
             }
             val rule = metadata.asReportingDescriptor(shortDescription = description)
             val sarifSchema = createSarifSchemaFromResults(rule = rule, results = results)
-            val sarifJson = SarifSerializer.toMinifiedJson(sarifSchema)
-            fileName.sink().buffer().use { sink ->
-                sink.writeUtf8(sarifJson)
+            fileName.outputStream().use { output ->
+                SarifSerializer.toMinifiedJson(sarifSchema, output)
             }
         }
 

--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/report/sarif/InvertSarifReportWriter.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/report/sarif/InvertSarifReportWriter.kt
@@ -45,7 +45,7 @@ class InvertSarifReportWriter(
             filename = jsonFileKey.filename
         )
 
-        sarifFile.outputStream().use { output ->
+        sarifFile.outputStream().buffered().use { output ->
             SarifSerializer.toMinifiedJson(sarif, output)
         }
     }
@@ -93,7 +93,7 @@ class InvertSarifReportWriter(
             }
             val rule = metadata.asReportingDescriptor(shortDescription = description)
             val sarifSchema = createSarifSchemaFromResults(rule = rule, results = results)
-            fileName.outputStream().use { output ->
+            fileName.outputStream().buffered().use { output ->
                 SarifSerializer.toMinifiedJson(sarifSchema, output)
             }
         }

--- a/invert-gradle-plugin/src/test/kotlin/com/squareup/invert/internal/report/InvertReportWriterTest.kt
+++ b/invert-gradle-plugin/src/test/kotlin/com/squareup/invert/internal/report/InvertReportWriterTest.kt
@@ -14,6 +14,8 @@ import com.squareup.invert.models.js.AllOwners
 import com.squareup.invert.models.js.BuildSystem
 import com.squareup.invert.models.js.MetadataJsReportModel
 import com.squareup.invert.models.js.TechDebtInitiative
+import io.github.detekt.sarif4k.SarifSerializer
+import io.github.detekt.sarif4k.fromJson
 import java.io.File
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
@@ -95,10 +97,12 @@ class InvertReportWriterTest {
     assertTrue(sarifFile.length() > 0, "Code references SARIF file should have content")
 
     // Verify SARIF content
-    val content = sarifFile.readText()
-    assertTrue(content.contains("\"id\":\"test_code_ref_stat\""), "Should contain rule ID")
-    assertTrue(content.contains("\"uri\":\"test.kt\""), "Should contain file path")
-    assertTrue(content.contains("\"text\":\"test code\""), "Should contain code snippet")
+    val sarif = sarifFile.inputStream().use { input -> SarifSerializer.fromJson(input) }
+    val run = sarif.runs.single()
+    assertTrue(run.tool.driver.rules!!.single().id == "test_code_ref_stat", "Should contain rule ID")
+    val result = run.results!!.single()
+    assertTrue(result.locations!![0].physicalLocation!!.artifactLocation!!.uri == "test.kt", "Should contain file path")
+    assertTrue(result.message.text == "test code", "Should contain code snippet")
   }
 
   @Test

--- a/invert-gradle-plugin/src/test/kotlin/com/squareup/invert/internal/report/InvertReportWriterTest.kt
+++ b/invert-gradle-plugin/src/test/kotlin/com/squareup/invert/internal/report/InvertReportWriterTest.kt
@@ -20,6 +20,7 @@ import java.io.File
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -99,10 +100,10 @@ class InvertReportWriterTest {
     // Verify SARIF content
     val sarif = sarifFile.inputStream().use { input -> SarifSerializer.fromJson(input) }
     val run = sarif.runs.single()
-    assertTrue(run.tool.driver.rules!!.single().id == "test_code_ref_stat", "Should contain rule ID")
+    assertEquals("test_code_ref_stat", run.tool.driver.rules!!.single().id, "Should contain rule ID")
     val result = run.results!!.single()
-    assertTrue(result.locations!![0].physicalLocation!!.artifactLocation!!.uri == "test.kt", "Should contain file path")
-    assertTrue(result.message.text == "test code", "Should contain code snippet")
+    assertEquals("test.kt", result.locations!![0].physicalLocation!!.artifactLocation!!.uri, "Should contain file path")
+    assertEquals("test code", result.message.text, "Should contain code snippet")
   }
 
   @Test

--- a/invert-gradle-plugin/src/test/kotlin/com/squareup/invert/internal/report/sarif/InvertSarifReportWriterTest.kt
+++ b/invert-gradle-plugin/src/test/kotlin/com/squareup/invert/internal/report/sarif/InvertSarifReportWriterTest.kt
@@ -11,8 +11,8 @@ import com.squareup.invert.models.StatMetadata
 import com.squareup.invert.models.js.StatsJsReportModel
 import io.github.detekt.sarif4k.SarifSerializer
 import io.github.detekt.sarif4k.fromJson
-import org.gradle.internal.impldep.org.testng.Assert.assertEquals
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import java.io.File
 

--- a/invert-gradle-plugin/src/test/kotlin/com/squareup/invert/internal/report/sarif/InvertSarifReportWriterTest.kt
+++ b/invert-gradle-plugin/src/test/kotlin/com/squareup/invert/internal/report/sarif/InvertSarifReportWriterTest.kt
@@ -9,6 +9,8 @@ import com.squareup.invert.models.Stat
 import com.squareup.invert.models.StatDataType
 import com.squareup.invert.models.StatMetadata
 import com.squareup.invert.models.js.StatsJsReportModel
+import io.github.detekt.sarif4k.SarifSerializer
+import io.github.detekt.sarif4k.fromJson
 import org.gradle.internal.impldep.org.testng.Assert.assertEquals
 import kotlin.test.Test
 import kotlin.test.assertTrue
@@ -35,9 +37,10 @@ class InvertSarifReportWriterTest {
         // Then
         val sarifFile = File(testDir, InvertFileUtils.SARIF_FOLDER_NAME + "/" + InvertPluginFileKey.STATS_SARIF.filename)
         assertTrue(sarifFile.exists(), "SARIF file should be created")
-        val content = sarifFile.readText()
-        assertTrue(content.contains("\"name\":\"invert\""), "Should contain tool name")
-        assertTrue(content.contains("\"version\":\"1.0.0\""), "Should contain tool version")
+        val sarif = sarifFile.inputStream().use { input -> SarifSerializer.fromJson(input) }
+        val run = sarif.runs.single()
+        assertEquals("invert", run.tool.driver.name, "Should contain tool name")
+        assertEquals("1.0.0", run.tool.driver.version, "Should contain tool version")
     }
 
     @Test
@@ -93,10 +96,12 @@ class InvertSarifReportWriterTest {
 
         // Then
         assertTrue(testFile.exists(), "SARIF file should be created")
-        val content = testFile.readText()
-        assertTrue(content.contains("\"id\":\"test_stat\""), "Should contain rule ID")
-        assertTrue(content.contains("\"text\":\"test code\""), "Should contain code snippet")
-        assertTrue(content.contains("\"uri\":\"test.kt\""), "Should contain file path")
+        val sarif = testFile.inputStream().use { input -> SarifSerializer.fromJson(input) }
+        val run = sarif.runs.single()
+        assertEquals("test_stat", run.tool.driver.rules!!.single().id, "Should contain rule ID")
+        val result = run.results!!.single()
+        assertEquals("test code", result.message.text, "Should contain code snippet")
+        assertEquals("test.kt", result.locations!![0].physicalLocation!!.artifactLocation!!.uri, "Should contain file path")
     }
 
 
@@ -192,4 +197,4 @@ class InvertSarifReportWriterTest {
             statsByModule = statsByModule
         )
     }
-} 
+}


### PR DESCRIPTION
## Summary
- switch invert SARIF writing to sarif4k's streaming serializer so large reports are written directly to the output stream
- bump sarif4k to the released `0.7.0` version and keep the plugin classpath exclusions in one shared helper
- tighten the SARIF writer tests to parse emitted SARIF structurally and use clearer equality assertions

## Testing
- `./gradlew :invert-gradle-plugin:dependencyInsight --dependency sarif4k --configuration runtimeClasspath`
- `./gradlew :invert-gradle-plugin:test --tests com.squareup.invert.internal.report.sarif.InvertSarifReportWriterTest --tests com.squareup.invert.internal.report.InvertReportWriterTest`

## Notes
- this is intended to unblock `block-invert-config` from consuming a published invert artifact that no longer materializes large SARIF payloads as a single string before writing