### PR TITLE
Prepare 0.0.13 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## Version 0.0.13
+
+* Stream SARIF serialization with sarif4k 0.7.0 to avoid materializing very large SARIF reports as a single string before writing.
+
+**Full Changelog**: https://github.com/square/invert/compare/0.0.12...0.0.13
+
 ## Version 0.0.12
 
 * Add a Gradle DSL option to disable aggregate `stats.sarif` generation while preserving per-stat `code_references_*.sarif` exports.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Invert is a Gradle Plugin with a dynamic web report that lets you gain insights 
 ```
 // Root build.gradle
 plugins {
-    id("com.squareup.invert") version "0.0.12"
+    id("com.squareup.invert") version "0.0.13"
 }
 repositories {
     mavenCentral() // Released Versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx16g
 kotlin.code.style=official
 android.useAndroidX=true
 group=com.squareup.invert
-version=0.0.12
+version=0.0.13
 
 # https://kotlinlang.org/docs/dokka-migration.html#enable-migration-helpers
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled


### PR DESCRIPTION
## Summary
- bump the published version metadata from `0.0.12` to `0.0.13`
- update the README install example to the new stable version
- add the `0.0.13` changelog entry for the streaming SARIF serialization work

## Testing
- not run (version/doc metadata only)