### PR TITLE
Bump version to 0.0.14-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx16g
 kotlin.code.style=official
 android.useAndroidX=true
 group=com.squareup.invert
-version=0.0.13
+version=0.0.14-SNAPSHOT
 
 # https://kotlinlang.org/docs/dokka-migration.html#enable-migration-helpers
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled


### PR DESCRIPTION
## Summary
- move `gradle.properties` to the next snapshot version after the 0.0.13 release

## Testing
- not run (version metadata only)