### PR TITLE
Move CI workflows to setup-gradle

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,8 +34,8 @@ jobs:
           java-version: '11'
           check-latest: true
 
-      - name: Gradle Wrapper Validation
-        uses: gradle/actions/wrapper-validation@v3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
 
 
       - name: Test on Ubuntu
@@ -60,6 +60,12 @@ jobs:
           distribution: 'zulu'
           java-version: '21' # Some of the projects we run invert against require Java 21
           check-latest: true
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: true
+          validate-wrappers: false
 
       - name: Run Invert on Test Projects and Generate GitHub Pages
         #        run: cd examples && ./gradlew :invert && cd ..
@@ -96,8 +102,11 @@ jobs:
           java-version: '11'
           check-latest: true
 
-      - name: Gradle Wrapper Validation
-        uses: gradle/actions/wrapper-validation@v3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: true
+          validate-wrappers: false
 
       - name: Retrieve Version from gradle.properties
         run: echo "VERSION_NAME=$(cat gradle.properties | grep "^version=" | awk -F'=' '{print $2}')" >> $GITHUB_ENV
@@ -130,8 +139,11 @@ jobs:
           java-version: '11'
           check-latest: true
 
-      - name: Gradle Wrapper Validation
-        uses: gradle/actions/wrapper-validation@v3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: true
+          validate-wrappers: false
 
       - name: Retrieve Version from gradle.properties
         run: echo "VERSION_NAME=$(cat gradle.properties | grep "^version=" | awk -F'=' '{print $2}')" >> $GITHUB_ENV

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
           check-latest: true
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
 
 
       - name: Test on Ubuntu
@@ -62,7 +62,7 @@ jobs:
           check-latest: true
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
         with:
           cache-read-only: true
           validate-wrappers: false
@@ -103,7 +103,7 @@ jobs:
           check-latest: true
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
         with:
           cache-read-only: true
           validate-wrappers: false
@@ -140,7 +140,7 @@ jobs:
           check-latest: true
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
         with:
           cache-read-only: true
           validate-wrappers: false

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -28,8 +28,8 @@ jobs:
           java-version: '17'
           check-latest: true
 
-      - name: Gradle Wrapper Validation
-        uses: gradle/actions/wrapper-validation@v3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Test on Ubuntu
         run: ./gradlew assemble check --no-daemon --stacktrace

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -29,7 +29,7 @@ jobs:
           check-latest: true
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v6
+        uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6
 
       - name: Test on Ubuntu
         run: ./gradlew assemble check --no-daemon --stacktrace


### PR DESCRIPTION
## Summary
- replace explicit `gradle/actions/wrapper-validation@v3` steps with `gradle/actions/setup-gradle`
- pin `gradle/actions/setup-gradle` to the current `v6` commit SHA instead of using the floating `@v6` tag
- let the primary test jobs keep automatic wrapper validation through `setup-gradle`
- disable wrapper validation in downstream `main` jobs that already depend on `test-ubuntu`, while still using `setup-gradle` for Gradle setup and cache access

## Testing
- parsed `.github/workflows/main.yml` and `.github/workflows/pr-checks.yml` with `python` + `yaml.safe_load`
- `git diff --check`

## Notes
- this modernizes the workflow to the current Gradle action, avoids separate wrapper-validation steps in the publish/pages jobs, and removes a floating action tag from the workflow definitions
