### PR TITLE
Retry 0.0.13 release publish

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx16g
 kotlin.code.style=official
 android.useAndroidX=true
 group=com.squareup.invert
-version=0.0.14-SNAPSHOT
+version=0.0.13
 
 # https://kotlinlang.org/docs/dokka-migration.html#enable-migration-helpers
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled


### PR DESCRIPTION
## Summary
- retry the `0.0.13` release publish from current `main` after the workflow migration to `setup-gradle`
- switch `gradle.properties` back from `0.0.14-SNAPSHOT` to `0.0.13` so the `publish-release` job runs on merge
- keep the retry minimal because the `0.0.13` tag, GitHub release, changelog entry, and README update already exist

## Testing
- `./gradlew assemble check --no-daemon --stacktrace`
- `git diff --check`

## Notes
- the original `0.0.13` release workflow failed repeatedly in the Gradle wrapper validation step before any build or publish step ran
- this retry is intended to publish the already-prepared `0.0.13` artifact under the updated workflow that now uses `gradle/actions/setup-gradle`
