### PR TITLE
Bump version to 0.0.14-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx16g
 kotlin.code.style=official
 android.useAndroidX=true
 group=com.squareup.invert
-version=0.0.13
+version=0.0.14-SNAPSHOT
 
 # https://kotlinlang.org/docs/dokka-migration.html#enable-migration-helpers
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled


### PR DESCRIPTION
## Summary
- bump `gradle.properties` from `0.0.13` back to `0.0.14-SNAPSHOT`
- restore mainline development version after publishing `0.0.13`

## Testing
- `git diff --check`

## Notes
- `0.0.13` has already been published to Maven Central
- this is the standard post-release snapshot bump only
