### PR TITLE
Chunked JSON transport for large stat payloads (Phase 1 + 2)

### DIFF
--- a/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/report/js/InvertJsReportWriter.kt
+++ b/invert-gradle-plugin/src/main/kotlin/com/squareup/invert/internal/report/js/InvertJsReportWriter.kt
@@ -6,6 +6,9 @@ import com.squareup.invert.internal.models.CollectedDependenciesForProject
 import com.squareup.invert.internal.models.CollectedPluginsForProject
 import com.squareup.invert.logging.InvertLogger
 import com.squareup.invert.models.InvertSerialization.InvertJson
+import com.squareup.invert.models.ModulePath
+import com.squareup.invert.models.Stat
+import com.squareup.invert.models.js.ChunkManifest
 import com.squareup.invert.models.js.CollectedStatTotalsJsReportModel
 import com.squareup.invert.models.js.ConfigurationsJsReportModel
 import com.squareup.invert.models.js.DependenciesJsReportModel
@@ -46,11 +49,17 @@ class InvertJsReportWriter(
     val modulesList = allProjectsDependencyData.map { it.path }
 
     val statsMapData: Set<StatJsReportModel> = InvertJsReportUtils.buildStatJsReportModelList(allProjectsStatsData)
-    statsMapData.forEach {
+    statsMapData.forEach { statModel ->
+      val fileKey = JsReportFileKey.STAT.key + "_" + statModel.statInfo.key
+      val serializedJson = InvertJson.encodeToString(StatJsReportModel.serializer(), statModel)
       writeJsFileInDir(
-        fileKey = JsReportFileKey.STAT.key + "_" + it.statInfo.key,
-        serializer = StatJsReportModel.serializer(),
-        value = it
+        fileKey = fileKey,
+        serializedJson = serializedJson,
+      )
+      writeChunkedStatIfNeeded(
+        fileKey = fileKey,
+        statModel = statModel,
+        serializedJsonLength = serializedJson.length,
       )
     }
 
@@ -152,6 +161,23 @@ class InvertJsReportWriter(
     value = value
   )
 
+  fun writeJsFileInDir(
+    fileKey: String,
+    serializedJson: String,
+  ) {
+    val jsOutputFile = InvertFileUtils.outputFile(
+      directory = rootBuildHtmlReportDir,
+      filename = "$fileKey.js"
+    )
+    if (!jsOutputFile.parentFile.exists()) {
+      jsOutputFile.parentFile.mkdirs()
+    }
+    jsOutputFile.sink().buffer().use { sink ->
+      sink.writeUtf8(invertJsGlobalVariableAssignment(fileKey = fileKey, value = serializedJson))
+    }
+    logger.lifecycle("Writing JavaScript $fileKey to file://${jsOutputFile.canonicalPath}")
+  }
+
   fun <T> writeJsFileInDir(
     fileKey: String,
     jsFilename: String,
@@ -168,7 +194,115 @@ class InvertJsReportWriter(
     value = value
   )
 
+  /**
+   * If [statModel] serializes to more than [CHUNK_THRESHOLD_BYTES], emit a chunk manifest
+   * and individual JSON chunk files alongside the legacy single-file JS.
+   *
+   * Each chunk is a valid [StatJsReportModel] containing the full [statInfo] and a subset
+   * of [statsByModule] entries, split on sorted module-key boundaries.
+   */
+  internal fun writeChunkedStatIfNeeded(
+    fileKey: String,
+    statModel: StatJsReportModel,
+    serializedJsonLength: Int = InvertJson.encodeToString(StatJsReportModel.serializer(), statModel).length,
+  ) {
+    if (serializedJsonLength < CHUNK_THRESHOLD_BYTES) return
+
+    val sortedModuleKeys = statModel.statsByModule.keys.sorted()
+    if (sortedModuleKeys.isEmpty()) return
+
+    val chunks = buildChunks(statModel, sortedModuleKeys)
+
+    val chunkFileNames = chunks.mapIndexed { index, _ ->
+      "$fileKey.chunk.$index.json"
+    }
+
+    // Write chunk files
+    chunks.forEachIndexed { index, chunkModel ->
+      val chunkFile = InvertFileUtils.outputFile(
+        directory = rootBuildHtmlReportDir,
+        filename = chunkFileNames[index]
+      )
+      chunkFile.sink().buffer().use { sink ->
+        sink.writeUtf8(InvertJson.encodeToString(StatJsReportModel.serializer(), chunkModel))
+      }
+      logger.lifecycle("Writing chunk ${index + 1}/${chunks.size} for $fileKey to file://${chunkFile.canonicalPath}")
+    }
+
+    // Write manifest
+    val manifest = ChunkManifest(
+      key = fileKey,
+      totalChunks = chunks.size,
+      chunkFiles = chunkFileNames,
+    )
+    val manifestFile = InvertFileUtils.outputFile(
+      directory = rootBuildHtmlReportDir,
+      filename = "$fileKey.manifest.json"
+    )
+    manifestFile.sink().buffer().use { sink ->
+      sink.writeUtf8(InvertJson.encodeToString(ChunkManifest.serializer(), manifest))
+    }
+    logger.lifecycle("Writing chunk manifest for $fileKey (${chunks.size} chunks) to file://${manifestFile.canonicalPath}")
+  }
+
   companion object {
+    /**
+     * Stat payloads larger than this threshold (in bytes of serialized JSON) are also
+     * emitted as chunked JSON files alongside the legacy single-file JS.
+     */
+    const val CHUNK_THRESHOLD_BYTES = 2_000_000
+
+    /**
+     * Target maximum size per chunk in bytes. Chunks may exceed this slightly because
+     * splitting happens on module boundaries.
+     */
+    private const val TARGET_CHUNK_SIZE_BYTES = 2_000_000
+
+    /**
+     * Build a list of [StatJsReportModel] chunks from the given model, splitting on
+     * sorted module-key boundaries so each chunk targets approximately [TARGET_CHUNK_SIZE_BYTES].
+     */
+    internal fun buildChunks(
+      statModel: StatJsReportModel,
+      sortedModuleKeys: List<ModulePath>,
+    ): List<StatJsReportModel> {
+      val chunks = mutableListOf<StatJsReportModel>()
+      var currentModules = mutableMapOf<ModulePath, Stat>()
+      var currentSize = 0L
+
+      // Pre-compute the fixed overhead of a chunk (statInfo + JSON structure) so we only
+      // measure the incremental cost of each module entry in the loop.
+      val emptyChunkSize = InvertJson.encodeToString(
+        StatJsReportModel.serializer(),
+        StatJsReportModel(statInfo = statModel.statInfo, statsByModule = emptyMap()),
+      ).length.toLong()
+
+      for (moduleKey in sortedModuleKeys) {
+        val stat = statModel.statsByModule[moduleKey] ?: continue
+        // Estimate incremental size: full single-entry model minus the fixed overhead.
+        val singleEntryModel = StatJsReportModel(
+          statInfo = statModel.statInfo,
+          statsByModule = mapOf(moduleKey to stat),
+        )
+        val entrySize = InvertJson.encodeToString(StatJsReportModel.serializer(), singleEntryModel).length.toLong() - emptyChunkSize
+
+        if (currentModules.isNotEmpty() && currentSize + entrySize > TARGET_CHUNK_SIZE_BYTES) {
+          chunks.add(StatJsReportModel(statInfo = statModel.statInfo, statsByModule = currentModules))
+          currentModules = mutableMapOf()
+          currentSize = 0L
+        }
+
+        currentModules[moduleKey] = stat
+        currentSize += entrySize
+      }
+
+      if (currentModules.isNotEmpty()) {
+        chunks.add(StatJsReportModel(statInfo = statModel.statInfo, statsByModule = currentModules))
+      }
+
+      return chunks
+    }
+
     /**
      * Utility method that concatenates the JS window variable assignment with the actual JSON.
      *

--- a/invert-gradle-plugin/src/main/resources/META-INF/invert.js
+++ b/invert-gradle-plugin/src/main/resources/META-INF/invert.js
@@ -68,6 +68,46 @@ window.externalLoadJavaScriptFile = function (key, callback) {
     })
 }
 
+/**
+ * Load a stat key via chunked JSON transport when a manifest is available.
+ * Falls back to legacy externalLoadJavaScriptFile if no manifest exists.
+ *
+ * Flow: fetch manifest → fetch all chunks in parallel → merge statsByModule → callback(json)
+ */
+window.externalLoadChunkedJsonFile = function (key, callback) {
+    var manifestUrl = "js/" + key + ".manifest.json";
+    fetch(manifestUrl)
+        .then(function (response) {
+            if (!response.ok) throw new Error("No manifest for " + key);
+            return response.json();
+        })
+        .then(function (manifest) {
+            return Promise.all(
+                manifest.chunkFiles.map(function (chunkFile) {
+                    return fetch("js/" + chunkFile).then(function (r) {
+                        if (!r.ok) throw new Error("Failed to fetch chunk: " + chunkFile);
+                        return r.json();
+                    });
+                })
+            );
+        })
+        .then(function (chunks) {
+            var merged = { statInfo: chunks[0].statInfo, statsByModule: {} };
+            chunks.forEach(function (chunk) {
+                var modules = chunk.statsByModule;
+                var keys = Object.keys(modules);
+                for (var i = 0; i < keys.length; i++) {
+                    merged.statsByModule[keys[i]] = modules[keys[i]];
+                }
+            });
+            callback(JSON.stringify(merged));
+        })
+        .catch(function (err) {
+            console.log("Chunked load unavailable for " + key + ", falling back to legacy: " + err.message);
+            externalLoadJavaScriptFile(key, callback);
+        });
+}
+
 // https://github.com/vasturiano/force-graph
 // https://unpkg.com/force-graph
 window.render3dGraph = function (domElementId, graphDataJson, width, height) {

--- a/invert-gradle-plugin/src/test/kotlin/com/squareup/invert/internal/report/js/InvertJsReportWriterTest.kt
+++ b/invert-gradle-plugin/src/test/kotlin/com/squareup/invert/internal/report/js/InvertJsReportWriterTest.kt
@@ -7,6 +7,7 @@ import com.squareup.invert.logging.InvertLogger
 import com.squareup.invert.models.ConfigurationName
 import com.squareup.invert.models.DependencyId
 import com.squareup.invert.models.GradlePluginId
+import com.squareup.invert.models.InvertSerialization.InvertJson
 import com.squareup.invert.models.ModulePath
 import com.squareup.invert.models.OwnerInfo
 import com.squareup.invert.models.Stat
@@ -14,6 +15,7 @@ import com.squareup.invert.models.StatDataType
 import com.squareup.invert.models.StatMetadata
 import com.squareup.invert.models.js.AllOwners
 import com.squareup.invert.models.js.BuildSystem
+import com.squareup.invert.models.js.ChunkManifest
 import com.squareup.invert.models.js.CollectedStatTotalsJsReportModel
 import com.squareup.invert.models.js.DependenciesJsReportModel
 import com.squareup.invert.models.js.DirectDependenciesJsReportModel
@@ -21,6 +23,7 @@ import com.squareup.invert.models.js.HistoricalData
 import com.squareup.invert.models.js.JsReportFileKey
 import com.squareup.invert.models.js.MetadataJsReportModel
 import com.squareup.invert.models.js.OwnershipJsReportModel
+import com.squareup.invert.models.js.StatJsReportModel
 import com.squareup.invert.models.js.StatsJsReportModel
 import okio.buffer
 import okio.source
@@ -29,6 +32,7 @@ import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
@@ -315,6 +319,195 @@ class InvertJsReportWriterTest {
     val content = testFile.source().buffer().use { it.readUtf8() }
     assertTrue(content.contains("window.invert_report"))
     assertTrue(content.contains("large_module_"))
+  }
+
+  // --- Chunked stat transport tests ---
+
+  @Test
+  fun `test small stat does not produce chunks or manifest`() {
+    val writer = InvertJsReportWriter(logger, testDir)
+    val statInfo = StatMetadata(key = "small_stat", description = "Small", dataType = StatDataType.NUMERIC)
+    val statModel = StatJsReportModel(
+      statInfo = statInfo,
+      statsByModule = mapOf(":app" to Stat.NumericStat(42))
+    )
+    val fileKey = "stat_small_stat"
+
+    writer.writeChunkedStatIfNeeded(fileKey, statModel)
+
+    val jsDir = File(testDir, "js")
+    assertFalse(File(jsDir, "$fileKey.manifest.json").exists(), "Manifest should not exist for small stat")
+    assertFalse(File(jsDir, "$fileKey.chunk.0.json").exists(), "Chunk should not exist for small stat")
+  }
+
+  @Test
+  fun `test large stat produces manifest and chunk files`() {
+    val writer = InvertJsReportWriter(logger, testDir)
+    val statModel = createLargeCodeReferenceStat(moduleCount = 200, refsPerModule = 50)
+    val fileKey = "stat_large_stat"
+
+    writer.writeChunkedStatIfNeeded(fileKey, statModel)
+
+    val jsDir = File(testDir, "js")
+    val manifestFile = File(jsDir, "$fileKey.manifest.json")
+    assertTrue(manifestFile.exists(), "Manifest should exist for large stat")
+
+    val manifest = InvertJson.decodeFromString(ChunkManifest.serializer(), manifestFile.readText())
+    assertEquals(fileKey, manifest.key)
+    assertEquals(1, manifest.version)
+    assertTrue(manifest.totalChunks > 1, "Should have multiple chunks, got ${manifest.totalChunks}")
+    assertEquals(manifest.totalChunks, manifest.chunkFiles.size)
+
+    manifest.chunkFiles.forEach { chunkFilename ->
+      assertTrue(File(jsDir, chunkFilename).exists(), "Chunk file $chunkFilename should exist")
+    }
+  }
+
+  @Test
+  fun `test chunk files are valid StatJsReportModel JSON`() {
+    val writer = InvertJsReportWriter(logger, testDir)
+    val statModel = createLargeCodeReferenceStat(moduleCount = 200, refsPerModule = 50)
+    val fileKey = "stat_valid_chunks"
+
+    writer.writeChunkedStatIfNeeded(fileKey, statModel)
+
+    val jsDir = File(testDir, "js")
+    val manifest = InvertJson.decodeFromString(
+      ChunkManifest.serializer(),
+      File(jsDir, "$fileKey.manifest.json").readText()
+    )
+
+    manifest.chunkFiles.forEach { chunkFilename ->
+      val chunkJson = File(jsDir, chunkFilename).readText()
+      val chunkModel = InvertJson.decodeFromString(StatJsReportModel.serializer(), chunkJson)
+      assertEquals(statModel.statInfo, chunkModel.statInfo, "Chunk statInfo should match original")
+      assertTrue(chunkModel.statsByModule.isNotEmpty(), "Chunk should have at least one module entry")
+    }
+  }
+
+  @Test
+  fun `test merged chunks equal original model`() {
+    val writer = InvertJsReportWriter(logger, testDir)
+    val statModel = createLargeCodeReferenceStat(moduleCount = 200, refsPerModule = 50)
+    val fileKey = "stat_merge_test"
+
+    writer.writeChunkedStatIfNeeded(fileKey, statModel)
+
+    val jsDir = File(testDir, "js")
+    val manifest = InvertJson.decodeFromString(
+      ChunkManifest.serializer(),
+      File(jsDir, "$fileKey.manifest.json").readText()
+    )
+
+    val mergedModules = mutableMapOf<ModulePath, Stat>()
+    manifest.chunkFiles.forEach { chunkFilename ->
+      val chunkModel = InvertJson.decodeFromString(
+        StatJsReportModel.serializer(),
+        File(jsDir, chunkFilename).readText()
+      )
+      mergedModules.putAll(chunkModel.statsByModule)
+    }
+
+    assertEquals(
+      statModel.statsByModule.keys.sorted(),
+      mergedModules.keys.sorted(),
+      "Merged chunk module keys should match original"
+    )
+    statModel.statsByModule.forEach { (moduleKey, stat) ->
+      assertEquals(stat, mergedModules[moduleKey], "Stat for $moduleKey should match after merge")
+    }
+  }
+
+  @Test
+  fun `test chunks do not have duplicate module keys`() {
+    val writer = InvertJsReportWriter(logger, testDir)
+    val statModel = createLargeCodeReferenceStat(moduleCount = 200, refsPerModule = 50)
+    val fileKey = "stat_no_dup_test"
+
+    writer.writeChunkedStatIfNeeded(fileKey, statModel)
+
+    val jsDir = File(testDir, "js")
+    val manifest = InvertJson.decodeFromString(
+      ChunkManifest.serializer(),
+      File(jsDir, "$fileKey.manifest.json").readText()
+    )
+
+    val allModuleKeys = mutableListOf<ModulePath>()
+    manifest.chunkFiles.forEach { chunkFilename ->
+      val chunkModel = InvertJson.decodeFromString(
+        StatJsReportModel.serializer(),
+        File(jsDir, chunkFilename).readText()
+      )
+      allModuleKeys.addAll(chunkModel.statsByModule.keys)
+    }
+
+    assertEquals(allModuleKeys.size, allModuleKeys.toSet().size, "No duplicate module keys across chunks")
+  }
+
+  @Test
+  fun `test buildChunks preserves all modules`() {
+    val statModel = createLargeCodeReferenceStat(moduleCount = 100, refsPerModule = 100)
+    val sortedKeys = statModel.statsByModule.keys.sorted()
+
+    val chunks = InvertJsReportWriter.buildChunks(statModel, sortedKeys)
+
+    val allModules = chunks.flatMap { it.statsByModule.keys }
+    assertEquals(
+      statModel.statsByModule.keys.sorted(),
+      allModules.sorted(),
+      "All modules should be present across chunks"
+    )
+    chunks.forEach { chunk ->
+      assertEquals(statModel.statInfo, chunk.statInfo, "Each chunk should carry the full statInfo")
+    }
+  }
+
+  @Test
+  fun `test buildChunks with single large module produces single chunk`() {
+    val statInfo = StatMetadata(key = "single_big", description = "Single Big", dataType = StatDataType.CODE_REFERENCES)
+    val bigRefs = (1..5000).map { i ->
+      Stat.CodeReferencesStat.CodeReference(
+        filePath = "src/main/kotlin/com/example/Big$i.kt",
+        startLine = i,
+        endLine = i + 10,
+        code = "fun bigMethod$i() { /* padding content to make this larger: ${"x".repeat(100)} */ }"
+      )
+    }
+    val statModel = StatJsReportModel(
+      statInfo = statInfo,
+      statsByModule = mapOf(":single-big-module" to Stat.CodeReferencesStat(bigRefs))
+    )
+    val sortedKeys = statModel.statsByModule.keys.sorted()
+
+    val chunks = InvertJsReportWriter.buildChunks(statModel, sortedKeys)
+
+    assertEquals(1, chunks.size, "Single module can't be split, should produce 1 chunk")
+    assertEquals(statModel.statsByModule, chunks.single().statsByModule)
+  }
+
+  private fun createLargeCodeReferenceStat(moduleCount: Int, refsPerModule: Int): StatJsReportModel {
+    val statInfo = StatMetadata(
+      key = "large_stat",
+      description = "Large Code Reference Stat",
+      dataType = StatDataType.CODE_REFERENCES,
+    )
+    val modules = (1..moduleCount).associate { moduleIdx ->
+      val refs = (1..refsPerModule).map { refIdx ->
+        Stat.CodeReferencesStat.CodeReference(
+          filePath = "src/main/kotlin/com/example/module$moduleIdx/File$refIdx.kt",
+          startLine = refIdx,
+          endLine = refIdx + 10,
+          code = "fun method$refIdx() { /* module $moduleIdx ref $refIdx padding ${"x".repeat(50)} */ }",
+          extras = mapOf(
+            "test_subtype" to "unit.jvm",
+            "host_module" to ":module-$moduleIdx",
+            "owner_slug" to "team-${moduleIdx % 10}",
+          )
+        )
+      }
+      ":module-$moduleIdx" to Stat.CodeReferencesStat(refs) as Stat
+    }
+    return StatJsReportModel(statInfo = statInfo, statsByModule = modules)
   }
 
   // Helper functions

--- a/invert-models/src/commonMain/kotlin/com/squareup/invert/models/js/ChunkManifest.kt
+++ b/invert-models/src/commonMain/kotlin/com/squareup/invert/models/js/ChunkManifest.kt
@@ -1,0 +1,22 @@
+package com.squareup.invert.models.js
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Manifest describing a chunked stat payload.
+ *
+ * When a stat file exceeds a size threshold, the writer emits a manifest file alongside
+ * multiple chunk files. The runtime can fetch this manifest, load chunks in parallel,
+ * and merge them back into a single [StatJsReportModel].
+ */
+@Serializable
+data class ChunkManifest(
+  /** Schema version for forward compatibility. */
+  val version: Int = 1,
+  /** The report file key this manifest describes (e.g. "stat_my_stat_key"). */
+  val key: String,
+  /** Total number of chunk files. */
+  val totalChunks: Int,
+  /** Ordered list of chunk filenames relative to the js/ directory. */
+  val chunkFiles: List<String>,
+)

--- a/invert-report/src/jsMain/kotlin/External.kt
+++ b/invert-report/src/jsMain/kotlin/External.kt
@@ -2,6 +2,8 @@
 
 external fun externalLoadJavaScriptFile(key: String, callback: (json: String) -> Unit)
 
+external fun externalLoadChunkedJsonFile(key: String, callback: (json: String) -> Unit)
+
 external fun loadJsFileAsync(url: String, callback: () -> Unit)
 
 external fun markdownToHtml(markdown: String): String

--- a/invert-report/src/jsMain/kotlin/navigation/RemoteJsLoadingProgress.kt
+++ b/invert-report/src/jsMain/kotlin/navigation/RemoteJsLoadingProgress.kt
@@ -16,6 +16,7 @@ import com.squareup.invert.models.js.OwnershipJsReportModel
 import com.squareup.invert.models.js.PluginsJsReportModel
 import com.squareup.invert.models.js.StatJsReportModel
 import com.squareup.invert.models.js.StatsJsReportModel
+import externalLoadChunkedJsonFile
 import externalLoadJavaScriptFile
 import kotlinx.browser.window
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -26,9 +27,9 @@ object RemoteJsLoadingProgress {
 
   fun getTimeoutForFileKey(jsReportFileKey: String): Int {
     return when (jsReportFileKey) {
-      JsReportFileKey.METADATA.key -> 10
-      else -> 30
-    } * 1_000
+      JsReportFileKey.METADATA.key -> 15_000
+      else -> 120_000
+    }
   }
 
   fun loadJavaScriptFile(fileKey: String, callback: (String) -> Unit) {
@@ -37,15 +38,21 @@ object RemoteJsLoadingProgress {
       Log.d("Loading $fileKey")
       val loadingTimeout = window.setTimeout(
         {
-          window.alert("Timeout while fetching $fileKey data.")
+          Log.d("Timeout while fetching $fileKey data.")
+          awaitingResults.value = awaitingResults.value.toMutableList().apply { remove(fileKey) }
         },
         getTimeoutForFileKey(fileKey)
       )
-      externalLoadJavaScriptFile(fileKey) { json ->
+      val onLoaded: (String) -> Unit = { json ->
         Log.d("Finished Loading $fileKey")
         window.clearTimeout(loadingTimeout)
         callback(json)
         awaitingResults.value = awaitingResults.value.toMutableList().apply { remove(fileKey) }
+      }
+      if (fileKey.startsWith("stat_")) {
+        externalLoadChunkedJsonFile(fileKey, onLoaded)
+      } else {
+        externalLoadJavaScriptFile(fileKey, onLoaded)
       }
     }
   }


### PR DESCRIPTION
## Summary

Large stat payloads in hosted Invert reports cause browser timeouts. This PR adds a **chunked JSON transport** that splits oversized stats into parallel-fetchable chunks and teaches the runtime to load them via `fetch()` instead of `<script>` tag injection.

## Phase 1: Producer-Side Chunking

When a stat file's serialized JSON exceeds 2 MB, `InvertJsReportWriter` emits:
- `js/stat_<key>.manifest.json` — chunk manifest
- `js/stat_<key>.chunk.N.json` — individual chunks (valid `StatJsReportModel` JSON each)
- `js/stat_<key>.js` — legacy single-file JS (always emitted for backward compat)

Each chunk contains the full `statInfo` and a subset of `statsByModule` entries, split on sorted module-key boundaries targeting ~2 MB per chunk.

## Phase 2: Runtime Chunked Loading

- `invert.js`: New `externalLoadChunkedJsonFile(key, callback)` — fetches manifest, loads all chunks in parallel via `fetch()`, merges `statsByModule`, passes merged JSON to callback. Falls back to legacy `externalLoadJavaScriptFile` if manifest 404s.
- `RemoteJsLoadingProgress`: Routes `stat_*` keys through chunked loader. Bumps timeouts from 10s/30s to 15s/120s. Replaces `window.alert()` on timeout with bounded state cleanup.
- `External.kt`: New `externalLoadChunkedJsonFile` external declaration.

## Why This Is Faster

| Step | Legacy | Chunked |
|------|--------|---------|
| Download | Single 100MB+ JS file | Parallel `fetch()` of ~2MB chunks |
| Parse | Browser JS engine parses/executes entire file | `fetch().json()` — no JS execution |
| Bridge | `JSON.stringify()` 100MB object back to string | Data arrives as JSON, stringified once |
| Timeout risk | 30s hard limit | 120s safety net, parallel fetches complete faster |

## Backward Compatibility

| Report Artifact | Runtime | Behavior |
|---|---|---|
| Legacy (no manifest) | Old runtime | Works (unchanged) |
| Legacy (no manifest) | New runtime | Works (manifest 404 → fallback) |
| Chunked + legacy JS | Old runtime | Works (ignores manifest, loads legacy) |
| Chunked + legacy JS | New runtime | Works (loads via chunks) |

## Files Changed

| File | Change |
|------|--------|
| `ChunkManifest.kt` | New model in invert-models |
| `InvertJsReportWriter.kt` | `writeChunkedStatIfNeeded()` + `buildChunks()` |
| `InvertJsReportWriterTest.kt` | 7 new tests |
| `invert.js` | `externalLoadChunkedJsonFile()` |
| `External.kt` | New external declaration |
| `RemoteJsLoadingProgress.kt` | Stat routing + timeout improvements |