### PR TITLE
Prepare 0.0.14 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## Version 0.0.14
+
+* Add chunked JSON transport for large stat payloads. Stats exceeding 2 MB are split into parallel-fetchable chunks alongside the legacy single-file JS. The runtime tries chunked loading first and falls back to legacy if no manifest is found.
+* Bump browser-side loading timeouts from 10s/30s to 15s/120s and replace `window.alert()` on timeout with bounded state cleanup.
+
+**Full Changelog**: https://github.com/square/invert/compare/0.0.13...0.0.14
+
 ## Version 0.0.13
 
 * Stream SARIF serialization with sarif4k 0.7.0 to avoid materializing very large SARIF reports as a single string before writing.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Invert is a Gradle Plugin with a dynamic web report that lets you gain insights 
 ```
 // Root build.gradle
 plugins {
-    id("com.squareup.invert") version "0.0.13"
+    id("com.squareup.invert") version "0.0.14"
 }
 repositories {
     mavenCentral() // Released Versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx16g
 kotlin.code.style=official
 android.useAndroidX=true
 group=com.squareup.invert
-version=0.0.14-SNAPSHOT
+version=0.0.14
 
 # https://kotlinlang.org/docs/dokka-migration.html#enable-migration-helpers
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled


### PR DESCRIPTION
## Release 0.0.14

### Changes since 0.0.13

* Add chunked JSON transport for large stat payloads. Stats exceeding 2 MB are split into parallel-fetchable chunks alongside the legacy single-file JS. The runtime tries chunked loading first and falls back to legacy if no manifest is found.
* Bump browser-side loading timeouts from 10s/30s to 15s/120s and replace `window.alert()` on timeout with bounded state cleanup.

### Release checklist

- [x] Version set to `0.0.14` in `gradle.properties`
- [x] `README.md` updated with new version
- [x] `CHANGELOG.md` updated

After merge, tag with:
```
git tag -a 0.0.14 -m "Version 0.0.14"
git push origin 0.0.14
```
Then create the release at https://github.com/square/invert/releases