### PR TITLE
Prepare 0.0.15 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## Version 0.0.15
+
+* Harden chunked stat loading so incomplete chunked reports fail visibly instead of falling back to empty legacy stats.
+* Add per-request timeouts and retries for manifest/chunk JSON loading, while preserving legacy loading when chunk transport is unavailable.
+* Route chunk, timeout, and decode failures through report load-failure state and show stat load failures on stat detail pages.
+
+**Full Changelog**: https://github.com/square/invert/compare/0.0.14...0.0.15
+
 ## Version 0.0.14
 
 * Add chunked JSON transport for large stat payloads. Stats exceeding 2 MB are split into parallel-fetchable chunks alongside the legacy single-file JS. The runtime tries chunked loading first and falls back to legacy if no manifest is found.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Invert is a Gradle Plugin with a dynamic web report that lets you gain insights 
 ```
 // Root build.gradle
 plugins {
-    id("com.squareup.invert") version "0.0.14"
+    id("com.squareup.invert") version "0.0.15"
 }
 repositories {
     mavenCentral() // Released Versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx16g
 kotlin.code.style=official
 android.useAndroidX=true
 group=com.squareup.invert
-version=0.0.15-SNAPSHOT
+version=0.0.15
 
 # https://kotlinlang.org/docs/dokka-migration.html#enable-migration-helpers
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled


### PR DESCRIPTION
[CLF-52](https://linear.app/squareup/issue/CLF-52/gate-d-wire-single-regeneratevalidatepublish-entry-point-into-local) release follow-up for the chunked stat loader hardening in #111.

Summary:
- Switches `gradle.properties` from `0.0.15-SNAPSHOT` to `0.0.15`.
- Updates the README plugin example to `0.0.15`.
- Adds 0.0.15 release notes for the chunked stat loading failure handling.

<details><summary>Additional context</summary>

This is the stable-version PR from `RELEASING.md`; merging it to `main` should trigger the release publish workflow. After it merges and publishes, the next steps are tagging `0.0.15`, creating the GitHub release, then opening the post-release `0.0.16-SNAPSHOT` bump PR.

</details>
