### PR TITLE
Bump version to 0.0.16-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.jvmargs=-Xmx16g
 kotlin.code.style=official
 android.useAndroidX=true
 group=com.squareup.invert
-version=0.0.15
+version=0.0.16-SNAPSHOT
 
 # https://kotlinlang.org/docs/dokka-migration.html#enable-migration-helpers
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled


### PR DESCRIPTION
Post-release version bump after publishing 0.0.15.

Summary:
- Updates `gradle.properties` from `0.0.15` to `0.0.16-SNAPSHOT`.
